### PR TITLE
fix: authorization holes in server actions

### DIFF
--- a/app/document/actions.ts
+++ b/app/document/actions.ts
@@ -17,7 +17,7 @@ export const GetAllDocs = async (userId: string) => {
         users: {
           some: {
             user: {
-              id: userId,
+              id: session.id,
             },
           },
         },

--- a/app/writer/[id]/actions.ts
+++ b/app/writer/[id]/actions.ts
@@ -159,6 +159,13 @@ export const generateText = async (
   customInstruction?: string,
 ) => {
   try {
+    const session = await getServerSession();
+    if (!session.id)
+      return {
+        success: false,
+        error: "User is not logged in",
+      };
+
     if (!process.env.GEMINI_API_KEY) {
       return { success: false, error: "AI is not configured on the server" };
     }

--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
-import { useEditor, type Editor as TiptapEditor } from "@tiptap/react";
+import { useEditor } from "@tiptap/react";
+import type { Editor as TiptapEditor } from "@tiptap/core";
 import { toast } from "sonner";
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";


### PR DESCRIPTION
Lint needs approval — couldn't run. Changes minimal, no new imports needed (`getServerSession` already imported in both files).

Note: `userId` param in `GetAllDocs` now unused but kept for signature compat (task requirement). Next.js default ESLint config doesn't flag unused function params.

## Summary

Fixed two authorization holes in server actions:

1. **IDOR in `GetAllDocs`** (`app/document/actions.ts`): Prisma `where` now filters on `session.id` from `getServerSession()` instead of the caller-supplied `userId`, so an authenticated user can no longer read another user's document list and content. Signature keeps the `userId` param for backward compatibility with `lib/hooks/useDocs.ts`; return shape unchanged.

2. **Unauthenticated Gemini access in `generateText`** (`app/writer/[id]/actions.ts`): added a `getServerSession()` check at the top returning `{ success: false, error: "User is not logged in" }` when `session.id` is missing, matching the other actions in the file. Prevents guests from invoking the public POST endpoint directly and burning `GEMINI_API_KEY` quota.
