### PR TITLE
fix: broken share link URL and dead Share button

### DIFF
--- a/app/document/components/Card/components/Options.tsx
+++ b/app/document/components/Card/components/Options.tsx
@@ -83,13 +83,13 @@ export default function CardOptions({ docId, inputRef }: CardOptionsPropType) {
 
   const shareDocument = () => {
     navigator.clipboard
-      .writeText(`${process.env.NEXT_PUBLIC_APP_URL}/writer/${docId}`)
+      .writeText(`${window.location.origin}/writer/${docId}`)
       .then(() => {
         toast.success("Share link copied to clipboard");
       })
       .catch((e) => {
         console.log(e);
-        toast.error(e);
+        toast.error("Couldn't copy link");
       })
       .finally(() => {
         setIsOptionsOpen(false);

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon, Sparkles } from "lucide-react";
 
+import { toast } from "sonner";
+
 import { RenameDocument } from "@/app/document/components/Card/actions";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import useDebounce from "@/lib/customHooks/useDebounce";
@@ -72,6 +74,18 @@ export default function Toolbar({ docId, name, isLoading, isNewDoc, isSaving, on
   };
   const debouncedSave = useDebounce(saveName, 1000);
 
+  const shareDocument = () => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        toast.success("Share link copied to clipboard");
+      })
+      .catch((e) => {
+        console.log(e);
+        toast.error("Couldn't copy link");
+      });
+  };
+
   return (
     <div className="h-[52px] border-b border-[var(--lp-border)] bg-[var(--lp-card)] flex items-center px-4 gap-3 shrink-0">
       {/* Logo — only shows on mobile (sidebar hides on mobile) */}
@@ -138,7 +152,10 @@ export default function Toolbar({ docId, name, isLoading, isNewDoc, isSaving, on
         </button>
 
         {/* Share */}
-        <button className="h-8 px-3 rounded-md text-[12.5px] font-medium transition-opacity hover:opacity-80 bg-[var(--lp-ink)] text-[var(--lp-paper)]">
+        <button
+          onClick={shareDocument}
+          className="h-8 px-3 rounded-md text-[12.5px] font-medium transition-opacity hover:opacity-80 bg-[var(--lp-ink)] text-[var(--lp-paper)]"
+        >
           Share
         </button>
       </div>

--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
-import { useEditor, type Editor as TiptapEditor } from "@tiptap/react";
+import { useEditor } from "@tiptap/react";
+import type { Editor as TiptapEditor } from "@tiptap/core";
 import { toast } from "sonner";
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";


### PR DESCRIPTION
Lint blocked by permission prompt (declined). Changes done regardless.

## Summary

Fixed document sharing in two places:

- **`app/document/components/Card/components/Options.tsx`** — `shareDocument` built the copied link from the undefined `NEXT_PUBLIC_APP_URL` env var, producing `undefined/writer/<id>`. Now uses `window.location.origin`. The catch handler passed the raw `Error` object to `toast.error` (unrenderable by sonner); now logs the error and shows the string `"Couldn't copy link"`.
- **`app/writer/[id]/components/Header/Header.tsx`** — the toolbar "Share" button had no `onClick` and did nothing. Wired it to copy `window.location.href` to the clipboard with `toast.success("Share link copied to clipboard")`, plus a string `toast.error` on clipboard failure. Imported `toast` from `sonner`.

Note: `yarn lint` was blocked by a permission prompt, so it did not run.
