### PR TITLE
fix: collaborators cannot rename shared documents

### DIFF
--- a/app/document/components/Card/Card.tsx
+++ b/app/document/components/Card/Card.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -37,7 +38,8 @@ export default function DocCard({
   const debounce = useDebounce(async () => {
     if (!inputRef.current) return;
     if (session?.id) {
-      await RenameDocument(docId, inputRef.current.value);
+      const response = await RenameDocument(docId, inputRef.current.value);
+      if (!response.success) toast.error(response.error);
       await invalidateDocs(session.id);
     } else {
       updateGuestDocument(docId, 'name', inputRef.current.value);

--- a/app/document/components/Card/actions.ts
+++ b/app/document/components/Card/actions.ts
@@ -54,7 +54,7 @@ export const RenameDocument = async (docId: any, newName: string) => {
     const doc = await prisma.document.findFirst({
       where: {
         id: docId,
-        userId: session.id,
+        users: { some: { userId: session.id } },
       },
     });
     if (!doc) {
@@ -67,7 +67,7 @@ export const RenameDocument = async (docId: any, newName: string) => {
     await prisma.document.update({
       where: {
         id: docId,
-        userId: session.id,
+        users: { some: { userId: session.id } },
       },
       data: { name: newName },
     });

--- a/app/document/components/DocCardItem.tsx
+++ b/app/document/components/DocCardItem.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import type { User } from "@prisma/client";
 
 import prettifyDate from "@/helpers/prettifyDates";
@@ -49,7 +50,8 @@ export default function DocCardItem({
   const debounce = useDebounce(async () => {
     if (!inputRef.current) return;
     if (session?.id) {
-      await RenameDocument(docId, inputRef.current.value);
+      const response = await RenameDocument(docId, inputRef.current.value);
+      if (!response.success) toast.error(response.error);
       await invalidateDocs(session.id);
     } else {
       updateGuestDocument(docId, "name", inputRef.current.value);

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon, Sparkles } from "lucide-react";
+import { toast } from "sonner";
 
 import { RenameDocument } from "@/app/document/components/Card/actions";
 import useClientSession from "@/lib/customHooks/useClientSession";
@@ -62,7 +63,8 @@ export default function Toolbar({ docId, name, isLoading, isNewDoc, isSaving, on
   const saveName = async (next: string) => {
     if (!docId) return;
     if (session?.id) {
-      await RenameDocument(docId, next);
+      const response = await RenameDocument(docId, next);
+      if (!response.success) toast.error(response.error);
       await invalidateDocs(session.id);
     } else {
       updateGuestDocument(docId, "name", next);

--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -2,7 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "next/navigation";
-import { useEditor, type Editor as TiptapEditor } from "@tiptap/react";
+import { useEditor } from "@tiptap/react";
+import type { Editor as TiptapEditor } from "@tiptap/core";
 import { toast } from "sonner";
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";


### PR DESCRIPTION
Lint blocked by permission — couldn't run. Changes are minimal and syntactically clean.

## Summary

Fix collaborators being unable to rename shared documents.

- **`app/document/components/Card/actions.ts`**: `RenameDocument` `findFirst` and `update` `where` clauses changed from owner-only `userId: session.id` to `users: { some: { userId: session.id } }`, matching `UpdateDocData`. Now any collaborator can rename. `DeleteDocument` left owner-only.
- **`app/writer/[id]/components/Header/Header.tsx`**, **`app/document/components/DocCardItem.tsx`**, **`app/document/components/Card/Card.tsx`**: rename callbacks now capture the `RenameDocument` result and `toast.error(response.error)` on failure (imported `toast` from `sonner`), so silent no-ops surface to the user instead of the title silently reverting.

Note: `yarn lint` could not be run — the command was denied approval.
