### PR TITLE
fix: duplicate toast import breaks writer build

### DIFF
--- a/app/document/components/DocTopBar.tsx
+++ b/app/document/components/DocTopBar.tsx
@@ -30,6 +30,7 @@ export default function DocTopBar({ q, setQ }: DocTopBarProps) {
   const session = useClientSession();
   const searchRef = useRef<HTMLDivElement>(null);
 
+  const [mounted, setMounted] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const [searchResponse, setSearchResponse] = useState<{
@@ -45,6 +46,8 @@ export default function DocTopBar({ q, setQ }: DocTopBarProps) {
     setSearchResponse(resp as any);
     setIsSearching(false);
   }, 500);
+
+  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -128,7 +131,7 @@ export default function DocTopBar({ q, setQ }: DocTopBarProps) {
           className="h-9 w-9 rounded-md border border-[var(--lp-border)] flex items-center justify-center transition hover:bg-[var(--lp-paper-2)]"
           aria-label="Toggle theme"
         >
-          {resolvedTheme === "dark" ? (
+          {mounted && resolvedTheme === "dark" ? (
             <Sun className="w-4 h-4 text-[var(--lp-ink)]" />
           ) : (
             <Moon className="w-4 h-4 text-[var(--lp-ink)]" />

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -5,8 +5,6 @@ import { useTheme } from "next-themes";
 import { Sun, Moon, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
-import { toast } from "sonner";
-
 import { RenameDocument } from "@/app/document/components/Card/actions";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import useDebounce from "@/lib/customHooks/useDebounce";

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -65,7 +65,6 @@ export default function AppSidebar({ onCreate, children, breakpoint = "md" }: Ap
         >
           <Plus className="w-4 h-4" strokeWidth={2} />
           New document
-          <span className="ml-auto font-mono text-[10px] opacity-70">⌘N</span>
         </button>
       </div>
 


### PR DESCRIPTION
Build/lint commands not approved in this environment. Changes complete; verify manually with `yarn build` and `yarn lint`.

## Summary

Three independent UI/build fixes:

- **`app/writer/[id]/components/Header/Header.tsx`** — removed the duplicate `import { toast } from "sonner";` (line 8). The duplicate identifier was a compile error breaking the writer page build.
- **`app/document/components/DocTopBar.tsx`** — added a `mounted` state set in a `useEffect`, and gated the theme icon on it (`mounted && resolvedTheme === "dark"`). Renders the stable Moon icon until mounted, fixing the next-themes hydration mismatch on first paint — same pattern as the writer toolbar.
- **`components/AppSidebar.tsx`** — removed the misleading `⌘N` badge from the "New document" button; no handler exists and Cmd/Ctrl+N is browser-reserved.
