### PR TITLE
fix: stop leaking owner email and auth fields

### DIFF
--- a/app/document/actions.ts
+++ b/app/document/actions.ts
@@ -27,7 +27,7 @@ export const GetAllDocs = async (userId: string) => {
         name: true,
         data: true,
         updatedAt: true,
-        createdBy: true,
+        createdBy: { select: { id: true, name: true, picture: true } },
         users: {
           select: {
             user: {

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -5,8 +5,6 @@ import { useTheme } from "next-themes";
 import { Sun, Moon, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
-import { toast } from "sonner";
-
 import { RenameDocument } from "@/app/document/components/Card/actions";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import useDebounce from "@/lib/customHooks/useDebounce";


### PR DESCRIPTION
Build command denied by permission. Change trivial + type-safe; DocTopBar reads `createdBy.name`, still in select.

---

**What changed:**

`app/document/actions.ts` — `GetAllDocs` Prisma `select` narrowed `createdBy: true` to `createdBy: { select: { id: true, name: true, picture: true } }`.

**Why:** `createdBy: true` returned the full owner `User` row — `email`, `password`, `verifyCode`, `verifyCodeExpiry` — to every collaborator over the wire for each document in the list. Now only public fields (`id`, `name`, `picture`) are sent.

**Verification:**
- Scanned `createdBy` consumers: only `DocTopBar.tsx` reads it (`createdBy.name`), still included in the narrowed select — no UI change needed.
- `SearchDocAction` (`Header/actions.ts`) already selects `name` only — left as-is.
- `GetDocDetails`/`UpdateDocData` in `app/writer/[id]/actions.ts` return raw `Document` rows (no user auth fields) — fine.
- `yarn build` not run: sandbox denied the command.
