### PR TITLE
fix: joining client overwrites live collab content

### DIFF
--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -5,8 +5,6 @@ import { useTheme } from "next-themes";
 import { Sun, Moon, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
-import { toast } from "sonner";
-
 import { RenameDocument } from "@/app/document/components/Card/actions";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import useDebounce from "@/lib/customHooks/useDebounce";

--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -64,6 +64,21 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
     };
   }, [provider, ydoc]);
 
+  // Wait for the websocket provider to sync before hydrating from the DB, so a
+  // joining client doesn't stomp newer in-flight content already in the Y.Doc.
+  // Fallback timer keeps offline / ws-down users loading their own content.
+  const [synced, setSynced] = useState(false);
+  useEffect(() => {
+    setSynced(false);
+    const onSync = () => setSynced(true);
+    provider.on("sync", onSync);
+    const fallback = setTimeout(() => setSynced(true), 3000);
+    return () => {
+      provider.off("sync", onSync);
+      clearTimeout(fallback);
+    };
+  }, [docId, provider]);
+
   // Save serialization: never run two persists in parallel. If onUpdate fires
   // again while a save is in flight, we just flip `pendingRef` and re-fire
   // once the current one resolves — using the editor's latest content at that
@@ -108,13 +123,6 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
 
   const editor = useEditor(
     {
-      onCreate: ({ editor: currentEditor }) => {
-        provider.on("sync", () => {
-          if (currentEditor.isEmpty) {
-            currentEditor.commands.setContent("");
-          }
-        });
-      },
       extensions: [
         ...extensions,
         Collaboration.configure({ document: ydoc }),
@@ -141,11 +149,15 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
   // different document without wiping in-progress typing on the current one.
   const hydratedDocRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!editor || !docData) return;
+    if (!editor || !docData || !synced) return;
     if (hydratedDocRef.current === docId) return;
-    editor.commands.setContent(docData.data ? JSON.parse(docData.data) : "");
+    // Only load the DB snapshot when peers left the shared doc empty; otherwise
+    // the Y.Doc already holds newer content and hydrating would overwrite it.
+    if (editor.isEmpty) {
+      editor.commands.setContent(docData.data ? JSON.parse(docData.data) : "");
+    }
     hydratedDocRef.current = docId;
-  }, [editor, docData, docId]);
+  }, [editor, docData, docId, synced]);
 
   return { editor, docData, error, isLoading };
 };


### PR DESCRIPTION
Build command needs approval. Change complete — summary:

---

Fix joining client overwriting live collaboration content in `app/writer/[id]/editor/index.ts`.

Previously the hydration effect called `editor.commands.setContent(...)` from the SWR DB snapshot as soon as the payload arrived, regardless of Yjs sync state. Since the editor uses the Collaboration extension, that rewrote the shared Y.Doc — a client joining a live room would stomp another user's newer in-flight content for everyone.

Changes:
- Added a `synced` state that resets on `docId`/`provider` change and flips true on the provider's `sync` event, with a 3-second fallback timer so offline / websocket-down users still load their content from the DB.
- Gated the hydration effect on `editor && docData && synced` (deps now `[editor, docData, docId, synced]`), keeping the `hydratedDocRef` per-doc guard. It only calls `setContent` when `editor.isEmpty`; if peers already populated the Y.Doc, it skips hydration and just marks the doc hydrated.
- Removed the now-redundant `provider.on("sync")` handler in `onCreate` that cleared content on sync.

Save/persist logic untouched. Verify with `yarn build`.
