### PR TITLE
fix: dashboard folder filters do nothing

### DIFF
--- a/app/document/actions.ts
+++ b/app/document/actions.ts
@@ -27,7 +27,7 @@ export const GetAllDocs = async (userId: string) => {
         name: true,
         data: true,
         updatedAt: true,
-        createdBy: true,
+        createdBy: { select: { id: true, name: true, picture: true } },
         users: {
           select: {
             user: {

--- a/app/document/components/DocumentContent.tsx
+++ b/app/document/components/DocumentContent.tsx
@@ -18,6 +18,7 @@ type Doc = {
   name: string;
   data: string | null;
   updatedAt: Date;
+  createdBy?: { id: string; name?: string; picture?: string | null };
   users: { user: { name: string; picture: string | null } }[];
 };
 
@@ -73,8 +74,15 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
     }
   };
 
+  const isGuest = !session?.id;
+
   const filtered = docs
     .filter(d => !q || d.name.toLowerCase().includes(q.toLowerCase()))
+    .filter(d => {
+      if (folder === "Drafts") return isGuest || d.createdBy?.id === session?.id;
+      if (folder === "Shared") return !isGuest && d.createdBy?.id !== session?.id;
+      return true;
+    })
     .sort((a, b) => {
       if (sort === "alpha") return a.name.localeCompare(b.name);
       return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
@@ -87,6 +95,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
 
   const firstName = session?.name?.split(" ")[0] ?? "there";
   const totalDocs = docs.length;
+  const folderLabel = folder === "Drafts" ? "My documents" : "Shared with me";
 
   return (
     <div className="h-screen w-screen flex overflow-hidden bg-[var(--lp-paper)] text-[var(--lp-ink)]">
@@ -101,10 +110,10 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
             {/* Page header */}
             <div className="mb-8">
               <div className="font-mono text-[10.5px] uppercase tracking-[0.18em] mb-2 text-[var(--lp-muted)]">
-                {folder === "all" ? "Your workspace" : folder}
+                {folder === "all" ? "Your workspace" : folderLabel}
               </div>
               <h1 className="text-[30px] sm:text-[38px] leading-[1.05] tracking-tight font-semibold text-[var(--lp-ink)]">
-                {folder === "all" ? `Welcome back, ${firstName}.` : folder}
+                {folder === "all" ? `Welcome back, ${firstName}.` : folderLabel}
               </h1>
               <p className="text-[14px] mt-2 text-[var(--lp-muted)]">
                 {folder === "all"

--- a/app/document/components/Sidebar.tsx
+++ b/app/document/components/Sidebar.tsx
@@ -1,16 +1,13 @@
 "use client";
 
-import { Layers2, PenLine, Users, Star, Lock, History } from "lucide-react";
+import { Layers2, PenLine, Users } from "lucide-react";
 
 import AppSidebar from "@/components/AppSidebar";
 
 const FOLDERS = [
-  { id: "all",      label: "All documents",  Icon: Layers2  },
-  { id: "Drafts",   label: "Drafts",          Icon: PenLine  },
-  { id: "Shared",   label: "Shared with me",  Icon: Users    },
-  { id: "Starred",  label: "Starred",         Icon: Star     },
-  { id: "Personal", label: "Personal",        Icon: Lock     },
-  { id: "Archive",  label: "Archive",         Icon: History  },
+  { id: "all",    label: "All documents",  Icon: Layers2 },
+  { id: "Drafts", label: "My documents",   Icon: PenLine },
+  { id: "Shared", label: "Shared with me", Icon: Users   },
 ];
 
 type SidebarProps = {

--- a/app/document/page.tsx
+++ b/app/document/page.tsx
@@ -11,6 +11,7 @@ export default async function DocumentPage() {
     name: string;
     data: string | null;
     updatedAt: Date;
+    createdBy: { id: string; name: string; picture: string | null };
     users: { user: { name: string; picture: string | null } }[];
   }[] = [];
 
@@ -26,6 +27,7 @@ export default async function DocumentPage() {
         name: true,
         data: true,
         updatedAt: true,
+        createdBy: { select: { id: true, name: true, picture: true } },
         users: {
           select: {
             user: {

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -5,8 +5,6 @@ import { useTheme } from "next-themes";
 import { Sun, Moon, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
-import { toast } from "sonner";
-
 import { RenameDocument } from "@/app/document/components/Card/actions";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import useDebounce from "@/lib/customHooks/useDebounce";

--- a/lib/guestServices.ts
+++ b/lib/guestServices.ts
@@ -59,7 +59,7 @@ export const getAllGuestDocuments = () => {
       thumbnail: doc.thumbnail,
       name: doc.name,
       updatedAt: doc.updatedAt,
-      createdBy: user.id,
+      createdBy: { id: user.id, name: user.name, picture: user.picture },
       users: [{
         user: {
           name: user.name,

--- a/lib/hooks/useDocs.ts
+++ b/lib/hooks/useDocs.ts
@@ -10,6 +10,7 @@ type Doc = {
   name: string;
   data: string | null;
   updatedAt: Date;
+  createdBy?: { id: string; name?: string; picture?: string | null };
   users: { user: { name: string; picture: string | null } }[];
 };
 


### PR DESCRIPTION
Build/typecheck need approval — couldn't run. Changes complete otherwise.

---

**fix: dashboard folder filters do nothing**

Sidebar folders only changed the heading; docs were never filtered by folder, and Starred/Personal/Archive had no backing data.

- `Sidebar.tsx`: reduced FOLDERS to `all` ("All documents"), `Drafts` ("My documents"), `Shared` ("Shared with me"). Dropped Starred/Personal/Archive and their unused icon imports.
- Ownership data plumbed to client:
  - `app/document/page.tsx`: added `createdBy: { select: { id, name, picture } }` to the query and to the `initialDocs` type.
  - `app/document/actions.ts`: narrowed `createdBy: true` to `createdBy: { select: { id, name, picture } }`.
  - `lib/guestServices.ts`: `getAllGuestDocuments` now returns `createdBy` as `{ id, name, picture }` (was a bare string) to match the DB shape.
  - Added optional `createdBy` to the `Doc` type in `lib/hooks/useDocs.ts` and `DocumentContent.tsx`.
- `DocumentContent.tsx`: `filtered` now filters by folder — `Drafts` keeps docs owned by the session user (guests: all), `Shared` keeps docs owned by someone else (guests: none). Header label/count show "My documents" / "Shared with me" instead of the raw folder id; Recent section unchanged (still `all`-only).

Note: `yarn build`/`tsc` require command approval in this environment, so the build was not run.
