### PR TITLE
feat: let collaborators leave a shared document

### DIFF
--- a/app/document/components/Card/actions.ts
+++ b/app/document/components/Card/actions.ts
@@ -17,7 +17,7 @@ export const DeleteDocument = async (docId: any) => {
     const doc = await prisma.document.findFirst({
       where: {
         id: docId,
-        userId: session.id,
+        users: { some: { userId: session.id } },
       },
     });
     if (!doc) {
@@ -27,15 +27,26 @@ export const DeleteDocument = async (docId: any) => {
       };
     }
 
-    await prisma.document.delete({
+    if (doc.userId === session.id) {
+      await prisma.document.delete({
+        where: {
+          id: docId,
+          userId: session.id,
+        },
+      });
+      revalidatePath("/");
+
+      return { success: true, data: "Document successfully deleted" };
+    }
+
+    await prisma.userOnDocument.delete({
       where: {
-        id: docId,
-        userId: session.id,
+        userId_documentId: { userId: session.id, documentId: docId },
       },
     });
     revalidatePath("/");
 
-    return { success: true, data: "Document successfully deleted" };
+    return { success: true, data: "Removed from your documents" };
   } catch (e) {
     console.log(e);
     return { success: false, error: "Internal server error" };

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -5,8 +5,6 @@ import { useTheme } from "next-themes";
 import { Sun, Moon, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 
-import { toast } from "sonner";
-
 import { RenameDocument } from "@/app/document/components/Card/actions";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import useDebounce from "@/lib/customHooks/useDebounce";


### PR DESCRIPTION
Build needs approval — denied. Change compiles cleanly by inspection (`userOnDocument` composite key `userId_documentId` matches schema join table). Run `yarn build` yourself to confirm.

Summary:

**feat: let collaborators leave a shared document**

`DeleteDocument` (`app/document/components/Card/actions.ts`) now branches on ownership instead of only matching the owner:
- Lookup uses `users: { some: { userId: session.id } }` so any member finds the doc (collaborators no longer get the false "Document does not exist").
- Owner (`doc.userId === session.id`): deletes the document as before → "Document successfully deleted".
- Collaborator: removes only their `userOnDocument` membership via `userId_documentId` composite key → "Removed from your documents".
- Kept existing `revalidatePath("/")` and error-handling shape. Client already toasts `response.data`, no UI change needed.
