### PR TITLE
fix: stop DB hydration clobbering live Yjs content

### DIFF
--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -64,6 +64,24 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
     };
   }, [provider, ydoc]);
 
+  // Readiness gate for DB hydration. We only trust the DB snapshot once Yjs has
+  // synced with peers (so we don't clobber their live, unsaved edits with the
+  // debounced-stale DB copy), or once the websocket is unreachable so an offline
+  // document still hydrates from the DB.
+  const [synced, setSynced] = useState(false);
+  useEffect(() => {
+    setSynced(false);
+    const markReady = () => setSynced(true);
+    provider.on("sync", markReady);
+    provider.on("connection-error", markReady);
+    provider.on("connection-close", markReady);
+    return () => {
+      provider.off("sync", markReady);
+      provider.off("connection-error", markReady);
+      provider.off("connection-close", markReady);
+    };
+  }, [provider]);
+
   // Save serialization: never run two persists in parallel. If onUpdate fires
   // again while a save is in flight, we just flip `pendingRef` and re-fire
   // once the current one resolves — using the editor's latest content at that
@@ -108,13 +126,6 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
 
   const editor = useEditor(
     {
-      onCreate: ({ editor: currentEditor }) => {
-        provider.on("sync", () => {
-          if (currentEditor.isEmpty) {
-            currentEditor.commands.setContent("");
-          }
-        });
-      },
       extensions: [
         ...extensions,
         Collaboration.configure({ document: ydoc }),
@@ -141,11 +152,16 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
   // different document without wiping in-progress typing on the current one.
   const hydratedDocRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!editor || !docData) return;
+    if (!editor || !docData || !synced) return;
     if (hydratedDocRef.current === docId) return;
-    editor.commands.setContent(docData.data ? JSON.parse(docData.data) : "");
+    // If peers already streamed live content into the shared Yjs doc, keep it —
+    // writing the stale DB snapshot here would broadcast it back and clobber
+    // their unsaved edits. Only hydrate from the DB when the editor is empty.
+    if (editor.isEmpty) {
+      editor.commands.setContent(docData.data ? JSON.parse(docData.data) : "");
+    }
     hydratedDocRef.current = docId;
-  }, [editor, docData, docId]);
+  }, [editor, docData, docId, synced]);
 
   return { editor, docData, error, isLoading };
 };


### PR DESCRIPTION
Done.

**Changes to `app/writer/[id]/editor/index.ts`:**
- Added `synced` React state + a `useEffect` on `[provider]` registering `sync`, `connection-error`, and `connection-close` listeners (all mark ready), resetting `synced=false` when `docId`/`provider` changes and cleaning up listeners.
- Removed the `onCreate` handler that registered `provider.on("sync")` and force-set empty content.
- Reworked the hydration effect to run only when `editor && docData && synced && hydratedDocRef.current !== docId`; it now calls `setContent` from the DB **only if `editor.isEmpty`**, otherwise just marks the doc hydrated without touching Yjs.

**Why:** Previously the DB snapshot was pushed via `setContent` as soon as SWR resolved, before Yjs sync — a second editor would overwrite live peer content with the debounce-stale DB copy, and Collaboration broadcast that back to all peers, causing data loss. Now hydration waits for Yjs sync (or websocket failure for offline use) and never clobbers peer-supplied content.
