### PR TITLE
fix: let collaborators remove a shared doc instead of failing

### DIFF
--- a/app/document/components/Card/actions.ts
+++ b/app/document/components/Card/actions.ts
@@ -17,7 +17,7 @@ export const DeleteDocument = async (docId: any) => {
     const doc = await prisma.document.findFirst({
       where: {
         id: docId,
-        userId: session.id,
+        users: { some: { userId: session.id } },
       },
     });
     if (!doc) {
@@ -27,15 +27,28 @@ export const DeleteDocument = async (docId: any) => {
       };
     }
 
-    await prisma.document.delete({
+    if (doc.userId === session.id) {
+      await prisma.document.delete({
+        where: {
+          id: docId,
+        },
+      });
+      revalidatePath("/");
+
+      return { success: true, data: "Document successfully deleted" };
+    }
+
+    await prisma.userOnDocument.delete({
       where: {
-        id: docId,
-        userId: session.id,
+        userId_documentId: {
+          userId: session.id,
+          documentId: docId,
+        },
       },
     });
     revalidatePath("/");
 
-    return { success: true, data: "Document successfully deleted" };
+    return { success: true, data: "Removed from your documents" };
   } catch (e) {
     console.log(e);
     return { success: false, error: "Internal server error" };


### PR DESCRIPTION
Done.

**fix: let collaborators remove a shared doc instead of failing**

`DeleteDocument` previously matched only documents owned by the caller (`userId === session.id`), so a collaborator clicking Delete always got "Document does not exist" and could not remove a shared doc from their dashboard.

- Lookup now uses a membership check (`users: { some: { userId: session.id } }`) instead of owner-only match; missing doc still returns "Document does not exist".
- Owner (`doc.userId === session.id`): deletes the whole document as before, returns "Document successfully deleted".
- Collaborator: deletes only their `UserOnDocument` membership row, returns "Removed from your documents".
- Kept `revalidatePath("/")` and the `{ success, data/error }` shape; no client changes needed.
