### PR TITLE
fix: show real document owner and make sidebar folders filter

### DIFF
--- a/app/document/components/DocCardItem.tsx
+++ b/app/document/components/DocCardItem.tsx
@@ -27,6 +27,7 @@ type DocCardItemProps = {
   data: string | null;
   title: string;
   updatedAt: Date;
+  createdBy: { id: string; name: string; picture: string | null };
   users: { user: Pick<User, "name" | "picture"> }[];
   view: "grid" | "list";
   colorIndex: number;
@@ -37,6 +38,7 @@ export default function DocCardItem({
   data,
   title,
   updatedAt,
+  createdBy,
   users,
   view,
   colorIndex,
@@ -59,7 +61,8 @@ export default function DocCardItem({
     }
   }, 1000);
 
-  const ownerName = users[0]?.user?.name ?? "You";
+  const isOwner = !session?.id || createdBy.id === session.id;
+  const ownerName = isOwner ? "You" : createdBy.name;
   const ownerInitial = (ownerName[0] ?? "?").toUpperCase();
   const formattedDate = prettifyDate(String(updatedAt), {
     month: "short",

--- a/app/document/components/DocumentContent.tsx
+++ b/app/document/components/DocumentContent.tsx
@@ -18,6 +18,7 @@ type Doc = {
   name: string;
   data: string | null;
   updatedAt: Date;
+  createdBy: { id: string; name: string; picture: string | null };
   users: { user: { name: string; picture: string | null } }[];
 };
 
@@ -73,7 +74,13 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
     }
   };
 
+  const isGuest = !userId;
   const filtered = docs
+    .filter(d => {
+      if (folder === "Drafts") return isGuest || d.createdBy.id === userId;
+      if (folder === "Shared") return !isGuest && d.createdBy.id !== userId;
+      return true;
+    })
     .filter(d => !q || d.name.toLowerCase().includes(q.toLowerCase()))
     .sort((a, b) => {
       if (sort === "alpha") return a.name.localeCompare(b.name);
@@ -139,6 +146,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                       data={d.data}
                       title={d.name}
                       updatedAt={d.updatedAt}
+                      createdBy={d.createdBy}
                       users={d.users}
                       view="grid"
                       colorIndex={i}
@@ -233,6 +241,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                       data={d.data}
                       title={d.name}
                       updatedAt={d.updatedAt}
+                      createdBy={d.createdBy}
                       users={d.users}
                       view="grid"
                       colorIndex={i}
@@ -251,6 +260,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                       data={d.data}
                       title={d.name}
                       updatedAt={d.updatedAt}
+                      createdBy={d.createdBy}
                       users={d.users}
                       view="list"
                       colorIndex={i}

--- a/app/document/components/Sidebar.tsx
+++ b/app/document/components/Sidebar.tsx
@@ -1,16 +1,13 @@
 "use client";
 
-import { Layers2, PenLine, Users, Star, Lock, History } from "lucide-react";
+import { Layers2, PenLine, Users } from "lucide-react";
 
 import AppSidebar from "@/components/AppSidebar";
 
 const FOLDERS = [
-  { id: "all",      label: "All documents",  Icon: Layers2  },
-  { id: "Drafts",   label: "Drafts",          Icon: PenLine  },
-  { id: "Shared",   label: "Shared with me",  Icon: Users    },
-  { id: "Starred",  label: "Starred",         Icon: Star     },
-  { id: "Personal", label: "Personal",        Icon: Lock     },
-  { id: "Archive",  label: "Archive",         Icon: History  },
+  { id: "all",    label: "All documents",  Icon: Layers2 },
+  { id: "Drafts", label: "Drafts",          Icon: PenLine },
+  { id: "Shared", label: "Shared with me",  Icon: Users   },
 ];
 
 type SidebarProps = {

--- a/app/document/page.tsx
+++ b/app/document/page.tsx
@@ -11,6 +11,7 @@ export default async function DocumentPage() {
     name: string;
     data: string | null;
     updatedAt: Date;
+    createdBy: { id: string; name: string; picture: string | null };
     users: { user: { name: string; picture: string | null } }[];
   }[] = [];
 
@@ -26,6 +27,7 @@ export default async function DocumentPage() {
         name: true,
         data: true,
         updatedAt: true,
+        createdBy: { select: { id: true, name: true, picture: true } },
         users: {
           select: {
             user: {

--- a/lib/guestServices.ts
+++ b/lib/guestServices.ts
@@ -59,7 +59,7 @@ export const getAllGuestDocuments = () => {
       thumbnail: doc.thumbnail,
       name: doc.name,
       updatedAt: doc.updatedAt,
-      createdBy: user.id,
+      createdBy: { id: user.id, name: user.name, picture: user.picture },
       users: [{
         user: {
           name: user.name,

--- a/lib/hooks/useDocs.ts
+++ b/lib/hooks/useDocs.ts
@@ -10,6 +10,7 @@ type Doc = {
   name: string;
   data: string | null;
   updatedAt: Date;
+  createdBy: { id: string; name: string; picture: string | null };
   users: { user: { name: string; picture: string | null } }[];
 };
 


### PR DESCRIPTION
Relation confirmed. All changes consistent with GetAllDocs. Done.

## Summary

fix: show real document owner and make sidebar folders filter

**Bug A — wrong owner shown.** Shared docs displayed a random collaborator as owner because `DocCardItem` read `users[0]?.user?.name` (arbitrary order). Now threaded the real owner via the `createdBy` relation:
- `app/document/page.tsx` — added `createdBy: { select: { id, name, picture } }` to the prisma select and to `initialDocs` type.
- `lib/hooks/useDocs.ts` — added `createdBy` to the `Doc` type.
- `lib/guestServices.ts` — `getAllGuestDocuments` now returns `createdBy: { id, name, picture }` (was a bare string, shape mismatch).
- `app/document/components/DocumentContent.tsx` — added `createdBy` to local `Doc` type and passed it to `DocCardItem` at all three render sites.
- `DocCardItem` — accepts `createdBy`, computes `ownerName`, shows "You" when `createdBy.id` matches the session user id or the user is a guest. `AvatarList` unchanged.

**Bug B — folders did nothing.** `filtered` ignored `folder`.
- `Sidebar.tsx` — trimmed `FOLDERS` to the three backed by data (All documents, Drafts, Shared with me); removed Starred/Personal/Archive.
- `DocumentContent.tsx` — folder filter composed before search+sort: `all` → everything; `Drafts` → own docs (all for guests); `Shared` → docs owned by someone else (empty for guests).
