### PR TITLE
fix: logout fails to clear secure session cookie in production

### DIFF
--- a/app/document/components/Header/actions.ts
+++ b/app/document/components/Header/actions.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { cookies } from "next/headers";
-
 import prisma from "@/prisma/prismaClient";
 import getServerSession from "@/lib/customHooks/getServerSession";
 
@@ -73,17 +71,6 @@ export const CreateNewDocument = async (initialData?: string) => {
     });
 
     return { success: true, data: doc };
-  } catch (e) {
-    console.error(e);
-    return { success: false, error: "Internal server error" };
-  }
-};
-
-export const LogoutAction = async () => {
-  try {
-    cookies().delete("next-auth.session-token");
-    cookies().delete("__Secure-next-auth.session-token");
-    return { success: true, data: null };
   } catch (e) {
     console.error(e);
     return { success: false, error: "Internal server error" };

--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -4,12 +4,12 @@ import { ReactNode } from "react";
 import Image from "next/image";
 import { Plus, LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { signOut } from "next-auth/react";
 import { toast } from "sonner";
 
 import logo from "@/public/logo.svg";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import getInitials from "@/helpers/getInitials";
-import { LogoutAction } from "@/app/document/components/Header/actions";
 
 type AppSidebarProps = {
   onCreate: () => void;
@@ -24,13 +24,8 @@ export default function AppSidebar({ onCreate, children, breakpoint = "md" }: Ap
   const initial = session?.name ? getInitials(session.name) : "G";
 
   const logout = async () => {
-    const response = await LogoutAction();
-    if (response.success) {
-      toast.success("Successfully logged out");
-      router.push("/login");
-    } else {
-      toast.error(response.error);
-    }
+    toast.success("Successfully logged out");
+    await signOut({ callbackUrl: "/login" });
   };
 
   const showClass = breakpoint === "lg" ? "lg:flex" : "md:flex";


### PR DESCRIPTION
Lint blocked by permissions. Changes complete; verified only AppSidebar referenced `LogoutAction` and `cookies` was the sole user of `next/headers` in that file (both removed).

---

Fix logout in production (HTTPS).

- `components/AppSidebar.tsx`: replaced the server-action logout with NextAuth client `signOut({ callbackUrl: "/login" })`. Dropped the `LogoutAction` import; added `import { signOut } from "next-auth/react"`. Kept a success toast before signing out. `signOut` clears the session client-side, so the UI updates immediately and NextAuth properly expires the `__Secure-`prefixed cookie.
- `app/document/components/Header/actions.ts`: removed the unused `LogoutAction` export and its now-unused `next/headers` `cookies` import.

Why: `cookies().delete()` emits a Set-Cookie without the `Secure` attribute, so browsers reject deletion of the `__Secure-next-auth.session-token` cookie and the user stayed logged in on HTTPS. The stale `SessionProvider` also kept the session in memory. `signOut` fixes both.
