### PR TITLE
fix: writer page flashes not-found screen while session resolves

### DIFF
--- a/app/writer/[id]/page.tsx
+++ b/app/writer/[id]/page.tsx
@@ -31,7 +31,9 @@ export default function WriterPage() {
 
   const isGuest = session !== null && !session.id;
 
-  const notFound = !!error || (!isLoading && !docData);
+  const sessionResolving = session === null;
+
+  const notFound = !!error || (!sessionResolving && !isLoading && !docData);
 
   const isNewDoc =
     !!docData &&


### PR DESCRIPTION
Done.

Fixed not-found flash on `/writer/[id]`: added `sessionResolving = session === null` and gated `notFound` on it (`!!error || (!sessionResolving && !isLoading && !docData)`). While `useClientSession` resolves, `useDoc` runs with a null key so SWR reports `isLoading:false, data:undefined`, which previously triggered the full-screen "document doesn't exist" view. Now that phase renders the editor layout with the `<Loading />` skeleton (unchanged, driven by `!docData`); once the session resolves, a genuinely missing doc still shows the not-found view.
