### PR TITLE
fix: pending debounced saves lost on navigation

### DIFF
--- a/app/document/components/DocCardItem.tsx
+++ b/app/document/components/DocCardItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import type { User } from "@prisma/client";
@@ -60,6 +60,13 @@ export default function DocCardItem({
       await invalidateDocs();
     }
   }, 1000);
+
+  // Flush a pending rename on unmount so it isn't lost within the 1s delay.
+  useEffect(() => {
+    return () => {
+      debounce.flush();
+    };
+  }, [debounce]);
 
   const isOwner = !session?.id || createdBy.id === session.id;
   const ownerName = isOwner ? "You" : createdBy.name;

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -80,6 +80,13 @@ export default function Toolbar({ docId, name, isLoading, isNewDoc, isSaving, on
   };
   const debouncedSave = useDebounce(saveName, 1000);
 
+  // Flush a pending name save on unmount so navigating away within 1s persists it.
+  useEffect(() => {
+    return () => {
+      debouncedSave.flush();
+    };
+  }, [debouncedSave]);
+
   const shareDocument = () => {
     if (session !== null && !session.id) {
       onAuthRequired();

--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -106,6 +106,17 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
 
   const debounce = useDebounce(persist, 1000);
 
+  // Flush any pending debounced save if the user closes the tab before the
+  // 1s delay fires, so the last edit isn't lost.
+  useEffect(() => {
+    const flush = () => debounce.flush();
+    window.addEventListener("beforeunload", flush);
+    return () => {
+      window.removeEventListener("beforeunload", flush);
+      debounce.flush();
+    };
+  }, [debounce]);
+
   const editor = useEditor(
     {
       onCreate: ({ editor: currentEditor }) => {


### PR DESCRIPTION
Done. All three consumers now flush pending debounced saves.

---

Fix pending debounced saves being dropped when a component unmounts before the 1s debounce fires (real data loss):

- **app/writer/[id]/editor/index.ts** — added an effect that flushes the debounced document-content save on unmount and registers a `window` `beforeunload` listener that flushes on tab close; listener is removed on cleanup.
- **app/writer/[id]/components/Header/Header.tsx** — added an unmount effect calling `debouncedSave.flush()` so an in-progress document-name edit persists on navigation.
- **app/document/components/DocCardItem.tsx** — added an unmount effect calling `debounce.flush()` (and imported `useEffect`) so a pending dashboard rename persists.

The lodash debounced function is memoized on the delay, so it's referentially stable and safe in the effect dependency arrays.
