### PR TITLE
fix: getInitials wrong for two-word names and crashes on empty input

### DIFF
--- a/helpers/getInitials.ts
+++ b/helpers/getInitials.ts
@@ -1,8 +1,9 @@
-const getInitials = (name: string) => {
-  let initials = name.split(" ");
+const getInitials = (name: string): string => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
 
-  if (initials.length > 2) return initials[0][0] + initials[1][0];
-  return initials[0][0];
+  if (parts.length === 0) return "";
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
 };
 
 export default getInitials;


### PR DESCRIPTION
Rewrote `helpers/getInitials.ts` defensively:

- Trim input, split on `/\s+/`, filter empty parts.
- Empty/whitespace input returns `""` instead of `undefined`.
- Two-or-more-word names now return both initials (`"John Smith"` → `"JS"`), fixing the `> 2` condition that only fired at 3+ words.
- Consecutive spaces (`"John  Smith"`) no longer yield `"Jundefined"` since empty segments are filtered.
- Result uppercased. Default export and `(name: string) => string` signature kept.

Callers (`Header.tsx`, `AppSidebar.tsx`, `AvatarList.tsx`) need no changes.
