### PR TITLE
fix: renaming a document to empty string saves blank name

### DIFF
--- a/app/document/components/Card/actions.ts
+++ b/app/document/components/Card/actions.ts
@@ -64,6 +64,14 @@ export const RenameDocument = async (docId: any, newName: string) => {
         error: "User is not logged in",
       };
 
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      return {
+        success: false,
+        error: "Name cannot be empty",
+      };
+    }
+
     const doc = await prisma.document.findFirst({
       where: {
         id: docId,
@@ -82,7 +90,7 @@ export const RenameDocument = async (docId: any, newName: string) => {
         id: docId,
         users: { some: { userId: session.id } },
       },
-      data: { name: newName },
+      data: { name: trimmed },
     });
     revalidatePath("/");
 

--- a/app/document/components/DocCardItem.tsx
+++ b/app/document/components/DocCardItem.tsx
@@ -51,12 +51,14 @@ export default function DocCardItem({
 
   const debounce = useDebounce(async () => {
     if (!inputRef.current) return;
+    const trimmed = inputRef.current.value.trim();
+    if (!trimmed) return;
     if (session?.id) {
-      const response = await RenameDocument(docId, inputRef.current.value);
+      const response = await RenameDocument(docId, trimmed);
       if (!response.success) toast.error(response.error);
       await invalidateDocs(session.id);
     } else {
-      updateGuestDocument(docId, "name", inputRef.current.value);
+      updateGuestDocument(docId, "name", trimmed);
       await invalidateDocs();
     }
   }, 1000);

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -68,12 +68,14 @@ export default function Toolbar({ docId, name, isLoading, isNewDoc, isSaving, on
 
   const saveName = async (next: string) => {
     if (!docId) return;
+    const trimmed = next.trim();
+    if (!trimmed) return;
     if (session?.id) {
-      const response = await RenameDocument(docId, next);
+      const response = await RenameDocument(docId, trimmed);
       if (!response.success) toast.error(response.error);
       await invalidateDocs(session.id);
     } else {
-      updateGuestDocument(docId, "name", next);
+      updateGuestDocument(docId, "name", trimmed);
       await invalidateDocs();
     }
     await invalidateDoc(docId);
@@ -120,6 +122,9 @@ export default function Toolbar({ docId, name, isLoading, isNewDoc, isSaving, on
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter") inputRef.current?.blur();
+            }}
+            onBlur={() => {
+              if (!nameValue.trim()) setNameValue(name);
             }}
             placeholder="Untitled"
             spellCheck={false}


### PR DESCRIPTION
Done. Blank titles no longer saved.

Changes:
- **app/document/components/Card/actions.ts** — `RenameDocument` now trims `newName`; returns `{ success: false, error: "Name cannot be empty" }` when empty before touching Prisma, otherwise saves the trimmed value.
- **app/writer/[id]/components/Header/Header.tsx** — `saveName` returns early (no server/guest call) when `next.trim()` is empty and saves the trimmed value on the guest path; added an `onBlur` that restores `nameValue` to the last non-empty `name` prop when the field is left blank.
- **app/document/components/DocCardItem.tsx** — debounced rename skips both `RenameDocument` and `updateGuestDocument` when the input trims to empty, and saves the trimmed value otherwise.

This stops clearing a title from persisting an empty name to the DB/localStorage, so the dashboard no longer shows blank cards.
