### PR TITLE
feat: make advertised ⌘N shortcut and writer-sidebar New document button work

### DIFF
--- a/app/document/components/DocumentContent.tsx
+++ b/app/document/components/DocumentContent.tsx
@@ -74,6 +74,17 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
     }
   };
 
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "n") {
+        e.preventDefault();
+        createDocument();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
   const isGuest = !userId;
   const filtered = docs
     .filter(d => {

--- a/app/writer/[id]/components/Tabs.tsx
+++ b/app/writer/[id]/components/Tabs.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
+import { toast } from "sonner";
 import { Search, Layers } from "lucide-react";
 
 import useClientSession from "@/lib/customHooks/useClientSession";
 import { useDocs } from "@/lib/hooks/useDocs";
+import { CreateNewDocument } from "@/app/document/components/Header/actions";
+import { createGuestDocument } from "@/lib/guestServices";
 import AppSidebar from "@/components/AppSidebar";
 
 function relativeTime(date: Date | string): string {
@@ -44,8 +47,35 @@ export default function LeftSidebar() {
 
   const filtered = docs.filter(d => !q || d.name.toLowerCase().includes(q.toLowerCase()));
 
+  const createDocument = async () => {
+    if (session?.id) {
+      const response = await CreateNewDocument();
+      if (response.success) {
+        toast.success("Successfully created new document");
+        router.push(`/writer/${response.data?.id}`);
+      } else {
+        toast.error(response.error);
+      }
+    } else {
+      const doc = createGuestDocument();
+      toast.success("Successfully created new document");
+      router.push(`/writer/${doc.id}`);
+    }
+  };
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "n") {
+        e.preventDefault();
+        createDocument();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
   return (
-    <AppSidebar onCreate={() => router.push("/document")} breakpoint="lg">
+    <AppSidebar onCreate={createDocument} breakpoint="lg">
       {/* Search */}
       <div className="px-3 mt-4">
         <div className="relative">


### PR DESCRIPTION
Good. Both compatible.

Changes done.

**PR description:**

Make the advertised ⌘N shortcut and the writer-page "New document" button actually create documents.

- `app/writer/[id]/components/Tabs.tsx`: replaced `onCreate={() => router.push("/document")}` (which just went to the dashboard) with a real `createDocument` handler mirroring `NewDocButton` — authenticated users call `CreateNewDocument()` and navigate to `/writer/<id>` on success (toast on error); guests call `createGuestDocument()` and navigate. Wired the sidebar button to it and registered a `keydown` window listener firing on ⌘N / Ctrl+N.
- `app/document/components/DocumentContent.tsx`: added a `keydown` window listener that on ⌘N / Ctrl+N calls `preventDefault()` and the existing `createDocument()`.

Both listeners are registered in a `useEffect` and removed on cleanup. Kept the existing toast copy and `{ success, data?, error? }` action pattern; no new abstractions.
