### PR TITLE
fix: stop Yjs + DB hydration from duplicating document content

### DIFF
--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -119,13 +119,6 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
 
   const editor = useEditor(
     {
-      onCreate: ({ editor: currentEditor }) => {
-        provider.on("sync", () => {
-          if (currentEditor.isEmpty) {
-            currentEditor.commands.setContent("");
-          }
-        });
-      },
       extensions: [
         ...extensions,
         Collaboration.configure({ document: ydoc }),
@@ -147,16 +140,33 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
     if (editor) editor.chain().focus().updateUser({ name }).run();
   }, [editor, name]);
 
-  // Hydrate the editor once per document from the server payload. Tracking by
-  // docId rather than a plain boolean lets us re-hydrate when navigating to a
-  // different document without wiping in-progress typing on the current one.
-  const hydratedDocRef = useRef<string | null>(null);
+  // The ydoc is the single source of truth. We only seed the DB payload into
+  // it once the provider has synced (so we know whether the room already holds
+  // content) AND the synced ydoc is genuinely empty. A `seeded` flag stored
+  // inside the ydoc's shared "meta" map means whichever client first connects
+  // to an empty room seeds it; every later client sees non-empty content or
+  // `seeded === true` and never re-inserts, so DB content is never appended on
+  // top of already-synced Yjs content.
   useEffect(() => {
     if (!editor || !docData) return;
-    if (hydratedDocRef.current === docId) return;
-    editor.commands.setContent(docData.data ? JSON.parse(docData.data) : "");
-    hydratedDocRef.current = docId;
-  }, [editor, docData, docId]);
+
+    const meta = ydoc.getMap("meta");
+    const seed = () => {
+      if (editor.isEmpty && !meta.get("seeded") && docData.data) {
+        editor.commands.setContent(JSON.parse(docData.data));
+        meta.set("seeded", true);
+      }
+    };
+
+    if (provider.synced) {
+      seed();
+    } else {
+      provider.on("sync", seed);
+    }
+    return () => {
+      provider.off("sync", seed);
+    };
+  }, [editor, docData, ydoc, provider]);
 
   return { editor, docData, error, isLoading };
 };


### PR DESCRIPTION
Done. `useRef` still used by save refs.

Scenarios:
- (a) first user, fresh doc + DB content: sync fires, ydoc empty, seed once, set `seeded`.
- (b) second user joins live room: ydoc synced non-empty, `editor.isEmpty` false, skip. No duplicate.
- (c) empty/new doc: `docData.data` falsy, skip. Editor stays empty.
- (d) websocket restart, ydoc empty again: sync fires, empty, DB re-seeds from source of truth.
- (e) A→B→A: docId change gives fresh ydoc/provider (useMemo keyed on docId); each seeds independently; live in-progress edits untouched since seed only runs when synced ydoc empty.

## Summary
- Removed the unconditional `hydratedDocRef` `useEffect` that called `setContent(docData.data)` on every editor mount, plus the `onCreate` `provider.on("sync")` clear hack (which leaked its listener).
- Added a single sync-gated seeding effect: after the provider syncs (or immediately if `provider.synced`), it seeds DB content into the ydoc only when the synced editor is empty, `docData.data` is non-empty, and the ydoc's shared `meta.seeded` flag is falsy — then sets `meta.set("seeded", true)`. The flag lives inside the ydoc so it's shared across clients, making the ydoc the single source of truth and preventing DB content from being appended onto already-synced Yjs content.
- The `provider.on("sync", ...)` handler is now registered and cleaned up via `provider.off` in the effect cleanup, so listeners don't leak across editor re-creations.
- Guest mode unchanged: guests still persist to localStorage via `updateGuestDocument`; seeding is independent of auth.

`editorConfig.ts` reviewed — no changes needed.
