### PR TITLE
fix: preserve paragraph structure when inserting AI-generated text

### DIFF
--- a/app/writer/[id]/components/AskPalette.tsx
+++ b/app/writer/[id]/components/AskPalette.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import type { Editor } from "@tiptap/react";
 
 import { generateText } from "../actions";
+import { insertGeneratedText } from "../editor/insertGeneratedText";
 import { generateTextOptions, LANGUAGES } from "./BubbleMenuComp/generateTextConfig";
 
 type Suggestion = { label: string; option: generateTextOptions };
@@ -122,16 +123,12 @@ export default function AskPalette({ open, onClose, editor, initialOption }: Ask
   const handleAccept = () => {
     if (!editor || !result) return;
     if (acceptReplacesSelection) {
-      // insertContent replaces the current selection if non-empty.
-      editor.chain().focus().insertContent(result).run();
+      // Replaces the current selection if non-empty.
+      insertGeneratedText(editor, result);
     } else {
       // No selection — append to the end so we don't clobber wherever the
       // caret happens to be.
-      editor
-        .chain()
-        .focus("end")
-        .insertContent(`\n\n${result}`)
-        .run();
+      insertGeneratedText(editor, result, { append: true });
     }
     setResult("");
     onClose();

--- a/app/writer/[id]/components/BubbleMenuComp/GeneratedText.tsx
+++ b/app/writer/[id]/components/BubbleMenuComp/GeneratedText.tsx
@@ -1,6 +1,7 @@
 import type { Editor } from "@tiptap/react";
 import { Check, Sparkles, Undo2, X } from "lucide-react";
 
+import { insertGeneratedText } from "../../editor/insertGeneratedText";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -32,7 +33,7 @@ export default function GeneratedText({
 }: GeneratedTextPropType) {
   const handleAccept = () => {
     if (!editor || !generativeTextResult) return;
-    editor.chain().focus().insertContent(generativeTextResult).run();
+    insertGeneratedText(editor, generativeTextResult);
     setGenerativeTextResult("");
     setIsAiActive(false);
   };

--- a/app/writer/[id]/components/RightRail.tsx
+++ b/app/writer/[id]/components/RightRail.tsx
@@ -7,6 +7,7 @@ import type { Editor } from "@tiptap/react";
 
 import useClientSession from "@/lib/customHooks/useClientSession";
 import { generateText } from "../actions";
+import { insertGeneratedText } from "../editor/insertGeneratedText";
 import { generateTextOptions } from "./BubbleMenuComp/generateTextConfig";
 
 type AIAction = {
@@ -87,7 +88,7 @@ export default function RightRail({
       toast.error(res.error);
       return;
     }
-    editor.chain().focus().insertContent(res.data || "").run();
+    insertGeneratedText(editor, res.data || "");
   };
 
   return (

--- a/app/writer/[id]/editor/insertGeneratedText.ts
+++ b/app/writer/[id]/editor/insertGeneratedText.ts
@@ -1,0 +1,42 @@
+import type { Editor } from "@tiptap/react";
+import type { JSONContent } from "@tiptap/react";
+
+// Convert a raw AI string into ProseMirror paragraph nodes so multi-paragraph
+// output keeps its structure. Blank lines separate paragraphs; single newlines
+// become hard breaks within a paragraph.
+function toParagraphNodes(raw: string): JSONContent[] {
+  return raw
+    .trim()
+    .split(/\n{2,}/)
+    .map((block) => {
+      const content: JSONContent[] = [];
+      block.split("\n").forEach((line, i) => {
+        if (i > 0) content.push({ type: "hardBreak" });
+        if (line) content.push({ type: "text", text: line });
+      });
+      return { type: "paragraph", content };
+    });
+}
+
+// Insert an AI result, preserving paragraph and line-break structure.
+// When `append` is true the content is added at the end of the document as new
+// paragraphs; otherwise it replaces the current selection.
+export function insertGeneratedText(
+  editor: Editor,
+  raw: string,
+  { append = false }: { append?: boolean } = {},
+) {
+  const paragraphs = toParagraphNodes(raw);
+  if (paragraphs.length === 0) return;
+
+  if (append) {
+    // Leading empty paragraph keeps a blank-line gap from existing content.
+    editor
+      .chain()
+      .focus("end")
+      .insertContent([{ type: "paragraph" }, ...paragraphs])
+      .run();
+  } else {
+    editor.chain().focus().insertContent(paragraphs).run();
+  }
+}


### PR DESCRIPTION
Done. Verify import path shape for GeneratedText (nested one dir deeper) is correct: `components/BubbleMenuComp/` → `../../editor/`. Correct.

## Summary

Fixed AI-generated text losing paragraph/line-break structure on insertion. Previously all insert paths passed a raw string to `insertContent`, which flattened newlines — multi-paragraph output (Summarize, Continue, Counter-argument, Make longer, Custom prompts) collapsed into one blob.

- **New helper** `app/writer/[id]/editor/insertGeneratedText.ts`: splits the raw string on blank lines (`/\n{2,}/`) into `paragraph` nodes and converts intra-paragraph single `\n` into `hardBreak` nodes, then inserts the ProseMirror content array via `editor.chain().insertContent(...)`. Trims outer whitespace. `append` option focuses the doc end and prepends an empty paragraph for a blank-line gap; otherwise it replaces the current selection.
- **Routed all three call sites** through the helper: `AskPalette.tsx` (replace-selection + append branches), `RightRail.tsx` (`handleAction`), and `BubbleMenuComp/GeneratedText.tsx` (`handleAccept`).

Single-line results stay one paragraph; multi-paragraph results keep each paragraph. Inserts go through editor commands so they still flow into Yjs collaboration.
