### PR TITLE
fix: dashboard card title sync and collaborator avatar overflow

### DIFF
--- a/app/document/components/DocCardItem.tsx
+++ b/app/document/components/DocCardItem.tsx
@@ -63,6 +63,12 @@ export default function DocCardItem({
     }
   }, 1000);
 
+  // Adopt an updated title prop (rename elsewhere, duplicate, collaborator
+  // change) unless the user is actively editing this input.
+  useEffect(() => {
+    if (document.activeElement !== inputRef.current) setName(title);
+  }, [title]);
+
   // Flush a pending rename on unmount so it isn't lost within the 1s delay.
   useEffect(() => {
     return () => {

--- a/components/AvatarList.tsx
+++ b/components/AvatarList.tsx
@@ -10,13 +10,25 @@ type AvatarListPropType = {
   }[];
 };
 
+const MAX_VISIBLE = 3;
+
 export default function AvatarList({ users }: AvatarListPropType) {
+  const visible = users.slice(0, MAX_VISIBLE);
+  const overflow = users.length - visible.length;
+
   return (
-    <div className="flex flex-row-reverse justify-end -space-x-2 space-x-reverse">
-      {users.map((e, index) => (
+    <div className="flex flex-row-reverse justify-end -space-x-2 space-x-reverse shrink-0">
+      {overflow > 0 && (
         <div
-          key={index}
-          className="relative flex justify-center items-center size-5 rounded-full text-[8px] font-bold ring-2 ring-[var(--lp-card)]"
+          className="relative flex justify-center items-center size-5 rounded-full text-[8px] font-bold ring-2 ring-[var(--lp-card)] shrink-0 bg-[var(--lp-paper-2)] text-[var(--lp-muted)]"
+        >
+          +{overflow}
+        </div>
+      )}
+      {visible.map((e, index) => (
+        <div
+          key={e.user.name ?? index}
+          className="relative flex justify-center items-center size-5 rounded-full text-[8px] font-bold ring-2 ring-[var(--lp-card)] shrink-0"
           style={{ background: "var(--lp-accent)", color: "white" }}
         >
           {e.user.picture ? (


### PR DESCRIPTION
Done.

**DocCardItem.tsx**: added effect syncing `title` prop into `name` state, but only when input not focused (`document.activeElement !== inputRef.current`), so external renames (SWR revalidation, duplicate, collaborator edit) refresh the card without clobbering in-progress typing. Debounce + flush-on-unmount untouched.

**AvatarList.tsx**: cap visible avatars at 3, render a trailing `+N` chip (same size/ring, `--lp-*` tokens) when more exist. Stable key from `user.name` instead of array index. Added `shrink-0` so avatars + chip never wrap or break the footer in grid or list views. Image-vs-initials rendering and `getInitials` fallback preserved.
