### PR TITLE
fix: restore link sharing and repair Yjs collaboration

### DIFF
--- a/app/document/components/Card/components/Options.tsx
+++ b/app/document/components/Card/components/Options.tsx
@@ -33,6 +33,8 @@ import LoaderButton from "@/components/LoaderButton";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import { invalidateDocs } from "@/lib/hooks/useDocs";
 
+import { GetSharing } from "@/app/writer/[id]/sharing/actions";
+
 import { DeleteDocument, RenameDocument } from "../actions";
 import { CreateNewDocument } from "../../Header/actions";
 
@@ -98,19 +100,33 @@ export default function CardOptions({
     router.push(`/writer/${docId}`);
   };
 
-  const shareDocument = () => {
-    navigator.clipboard
-      .writeText(`${window.location.origin}/writer/${docId}`)
-      .then(() => {
-        toast.success("Share link copied to clipboard");
-      })
-      .catch((e) => {
-        console.log(e);
-        toast.error("Couldn't copy link");
-      })
-      .finally(() => {
-        setIsOptionsOpen(false);
-      });
+  const shareDocument = async () => {
+    setIsOptionsOpen(false);
+
+    const response = await GetSharing(docId);
+    if (!response.success || !response.data) {
+      toast.error(response.error);
+      return;
+    }
+
+    // A link is only worth copying once link access is on — otherwise it
+    // resolves to "does not exist" for whoever receives it.
+    if (response.data.linkAccess === "NONE") {
+      toast.warning(
+        "Link sharing is off. Open the document and turn on “Anyone with the link”.",
+      );
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(
+        `${window.location.origin}/writer/${docId}`,
+      );
+      toast.success("Link copied — anyone with it can edit");
+    } catch (e) {
+      console.log(e);
+      toast.error("Couldn't copy link");
+    }
   };
 
   const duplicateDocument = async () => {

--- a/app/writer/[id]/actions.ts
+++ b/app/writer/[id]/actions.ts
@@ -4,6 +4,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 
 import prisma from "@/prisma/prismaClient";
 import getServerSession from "@/lib/customHooks/getServerSession";
+import { joinViaLink, resolveDocumentAccess } from "@/lib/documentAccess";
 import {
   generateTextOptions,
   prompts,
@@ -18,25 +19,20 @@ export const GetDocDetails = async (id: any) => {
         error: "User is not logged in",
       };
 
-    // Read-only: opening a document must never grant access to it. Membership
-    // is written by document creation and by an explicit share, so a caller who
-    // is not already in UserOnDocument gets the same answer as for a document
-    // that does not exist.
-    const doc = await prisma.document.findFirst({
-      where: {
-        id,
-        users: {
-          some: { userId: session.id },
-        },
-      },
-    });
-    if (!doc)
+    // Opening a document grants access only when the owner has shared its link.
+    // A caller who is neither a collaborator nor holding a shared link gets the
+    // same answer as for a document that does not exist, so ids cannot be
+    // probed for existence.
+    const access = await resolveDocumentAccess(id, session.id);
+    if (!access)
       return {
         success: false,
         error: "Document does not exist",
       };
 
-    return { success: true, data: doc };
+    if (!access.isMember) await joinViaLink(id, session.id);
+
+    return { success: true, data: access.document };
   } catch (e) {
     console.log(e);
     return { success: false, error: "Internal server error" };

--- a/app/writer/[id]/components/Header/Header.tsx
+++ b/app/writer/[id]/components/Header/Header.tsx
@@ -14,6 +14,7 @@ import { invalidateDoc } from "@/lib/hooks/useDoc";
 import { invalidateDocs } from "@/lib/hooks/useDocs";
 import getInitials from "@/helpers/getInitials";
 import ExportMenu from "./ExportMenu";
+import ShareDialog from "./ShareDialog";
 
 function DocxLogo({ className = "h-5 w-5" }: { className?: string }) {
   return (
@@ -92,22 +93,6 @@ export default function Toolbar({ docId, name, data, editor, isLoading, isNewDoc
       debouncedSave.flush();
     };
   }, [debouncedSave]);
-
-  const shareDocument = () => {
-    if (session !== null && !session.id) {
-      onAuthRequired();
-      return;
-    }
-    navigator.clipboard
-      .writeText(window.location.href)
-      .then(() => {
-        toast.success("Share link copied to clipboard");
-      })
-      .catch((e) => {
-        console.log(e);
-        toast.error("Couldn't copy link");
-      });
-  };
 
   return (
     <div className="h-[52px] border-b border-[var(--lp-border)] bg-[var(--lp-card)] flex items-center px-4 gap-3 shrink-0">
@@ -190,12 +175,12 @@ export default function Toolbar({ docId, name, data, editor, isLoading, isNewDoc
         </button>
 
         {/* Share */}
-        <button
-          onClick={shareDocument}
-          className="h-8 px-3 rounded-md text-[12.5px] font-medium transition-opacity hover:opacity-80 bg-[var(--lp-ink)] text-[var(--lp-paper)]"
-        >
-          Share
-        </button>
+        <ShareDialog
+          docId={docId}
+          name={name}
+          isGuest={session !== null && !session.id}
+          onAuthRequired={onAuthRequired}
+        />
       </div>
     </div>
   );

--- a/app/writer/[id]/components/Header/ShareDialog.tsx
+++ b/app/writer/[id]/components/Header/ShareDialog.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Copy, Globe, Link2Off, Loader2, X } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Avatar, AvatarImage } from "@/components/ui/avatar";
+import getInitials from "@/helpers/getInitials";
+import {
+  AddCollaborator,
+  GetSharing,
+  RemoveCollaborator,
+  SearchUsers,
+  SetLinkAccess,
+  type SharedUser,
+} from "../../sharing/actions";
+
+type ShareDialogProps = {
+  docId: string;
+  name: string;
+  isGuest: boolean;
+  onAuthRequired: () => void;
+};
+
+type LinkAccessValue = "NONE" | "EDIT";
+
+function PersonRow({
+  person,
+  canRemove,
+  onRemove,
+}: {
+  person: SharedUser;
+  canRemove: boolean;
+  onRemove: () => void;
+}) {
+  return (
+    <li className="flex items-center gap-2.5 py-1.5">
+      <Avatar className="size-8 shrink-0 bg-[var(--lp-paper-2)]">
+        {person.picture && <AvatarImage src={person.picture} />}
+        <span className="grid place-items-center h-full w-full text-[11px] font-medium text-[var(--lp-muted)]">
+          {getInitials(person.name || "?")}
+        </span>
+      </Avatar>
+      <div className="min-w-0 flex-1">
+        <p className="text-[13px] font-medium truncate">{person.name}</p>
+        <p className="text-[12px] text-[var(--lp-muted)] truncate">
+          {person.email}
+        </p>
+      </div>
+      <span className="text-[12px] text-[var(--lp-muted)] shrink-0">
+        {person.isOwner ? "Owner" : "Editor"}
+      </span>
+      {canRemove && !person.isOwner && (
+        <button
+          onClick={onRemove}
+          aria-label={`Remove ${person.name}`}
+          className="shrink-0 h-6 w-6 grid place-items-center rounded-md text-[var(--lp-muted)] transition-colors hover:bg-[var(--lp-paper-2)] hover:text-[var(--lp-ink)]"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      )}
+    </li>
+  );
+}
+
+export default function ShareDialog({
+  docId,
+  name,
+  isGuest,
+  onAuthRequired,
+}: ShareDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [people, setPeople] = useState<SharedUser[]>([]);
+  const [linkAccess, setLinkAccess] = useState<LinkAccessValue>("NONE");
+  const [isOwner, setIsOwner] = useState(false);
+  const [email, setEmail] = useState("");
+  const [isAdding, setIsAdding] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [suggestions, setSuggestions] = useState<SharedUser[]>([]);
+
+  const shared = linkAccess === "EDIT";
+
+  // Debounced so typing an address is one search, not one per keystroke. The
+  // stale flag drops results from a query the user has already typed past.
+  useEffect(() => {
+    if (!open || !isOwner || !email.trim()) {
+      setSuggestions([]);
+      return;
+    }
+
+    let stale = false;
+    const timer = setTimeout(async () => {
+      const response = await SearchUsers(docId, email);
+      if (stale) return;
+      setSuggestions(response.success ? (response.data as SharedUser[]) : []);
+    }, 250);
+
+    return () => {
+      stale = true;
+      clearTimeout(timer);
+    };
+  }, [email, open, isOwner, docId]);
+
+  const openChange = async (next: boolean) => {
+    if (next && isGuest) {
+      onAuthRequired();
+      return;
+    }
+    setOpen(next);
+    if (!next || !docId) return;
+
+    setLoaded(false);
+    const response = await GetSharing(docId);
+    if (!response.success || !response.data) {
+      toast.error(response.error);
+      setOpen(false);
+      return;
+    }
+    setPeople(response.data.people);
+    setLinkAccess(response.data.linkAccess as LinkAccessValue);
+    setIsOwner(response.data.isOwner);
+    setLoaded(true);
+  };
+
+  const addPerson = async (value: string) => {
+    if (!value.trim() || isAdding) return;
+
+    setIsAdding(true);
+    const response = await AddCollaborator(docId, value);
+    setIsAdding(false);
+
+    if (!response.success || !response.data) {
+      toast.error(response.error);
+      return;
+    }
+    setPeople((current) => [...current, response.data as SharedUser]);
+    setEmail("");
+    setSuggestions([]);
+    toast.success(`${response.data.name} can now edit`);
+  };
+
+  const removePerson = async (person: SharedUser) => {
+    const previous = people;
+    setPeople((current) => current.filter((p) => p.id !== person.id));
+
+    const response = await RemoveCollaborator(docId, person.id);
+    if (!response.success) {
+      setPeople(previous);
+      toast.error(response.error);
+      return;
+    }
+    toast.success(`Removed ${person.name}`);
+  };
+
+  const toggleLink = async () => {
+    const next: LinkAccessValue = shared ? "NONE" : "EDIT";
+    setIsUpdating(true);
+    setLinkAccess(next);
+
+    const response = await SetLinkAccess(docId, next);
+    setIsUpdating(false);
+    if (!response.success) {
+      setLinkAccess(shared ? "EDIT" : "NONE");
+      toast.error(response.error);
+    }
+  };
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      toast.success("Link copied — anyone with it can edit");
+    } catch {
+      toast.error("Couldn't copy link");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={openChange}>
+      <DialogTrigger asChild>
+        <button className="h-8 px-3 rounded-md text-[12.5px] font-medium transition-opacity hover:opacity-80 bg-[var(--lp-ink)] text-[var(--lp-paper)]">
+          Share
+        </button>
+      </DialogTrigger>
+
+      <DialogContent className="sm:max-w-[460px] border-[var(--lp-border)] bg-[var(--lp-card)] text-[var(--lp-ink)]">
+        <DialogHeader>
+          <DialogTitle className="text-[15px]">
+            Share &ldquo;{name.trim() || "Untitled"}&rdquo;
+          </DialogTitle>
+          <DialogDescription className="text-[12.5px] text-[var(--lp-muted)]">
+            Everyone you share with can edit. There is no view-only access yet.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!loaded ? (
+          <div className="py-8 grid place-items-center">
+            <Loader2 className="w-4 h-4 animate-spin text-[var(--lp-muted)]" />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {isOwner && (
+              <div className="relative">
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    addPerson(email);
+                  }}
+                  className="flex gap-2"
+                >
+                  <input
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="Add people by name or email"
+                    autoComplete="off"
+                    className="flex-1 h-9 px-3 rounded-md border border-[var(--lp-border)] bg-[var(--lp-paper)] text-[13px] outline-none placeholder:text-[var(--lp-muted)] focus:border-[var(--lp-accent)]"
+                  />
+                  <button
+                    type="submit"
+                    disabled={!email.trim() || isAdding}
+                    className="h-9 px-3.5 rounded-md text-[12.5px] font-medium bg-[var(--lp-ink)] text-[var(--lp-paper)] transition-opacity hover:opacity-80 disabled:opacity-40"
+                  >
+                    {isAdding ? "Adding…" : "Add"}
+                  </button>
+                </form>
+
+                {suggestions.length > 0 && (
+                  <ul className="absolute z-20 left-0 right-0 mt-1 rounded-md border border-[var(--lp-border)] bg-[var(--lp-card)] shadow-lg overflow-hidden">
+                    {suggestions.map((user) => (
+                      <li key={user.id}>
+                        <button
+                          type="button"
+                          onClick={() => addPerson(user.email)}
+                          className="w-full flex items-center gap-2.5 px-2.5 py-2 text-left transition-colors hover:bg-[var(--lp-paper-2)]"
+                        >
+                          <Avatar className="size-7 shrink-0 bg-[var(--lp-paper-2)]">
+                            {user.picture && <AvatarImage src={user.picture} />}
+                            <span className="grid place-items-center h-full w-full text-[10px] font-medium text-[var(--lp-muted)]">
+                              {getInitials(user.name || "?")}
+                            </span>
+                          </Avatar>
+                          <div className="min-w-0">
+                            <p className="text-[13px] truncate">{user.name}</p>
+                            <p className="text-[12px] text-[var(--lp-muted)] truncate">
+                              {user.email}
+                            </p>
+                          </div>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            <div>
+              <p className="text-[12px] font-medium text-[var(--lp-muted)] mb-1">
+                People with access
+              </p>
+              <ul className="max-h-[220px] overflow-y-auto">
+                {people.map((person) => (
+                  <PersonRow
+                    key={person.id}
+                    person={person}
+                    canRemove={isOwner}
+                    onRemove={() => removePerson(person)}
+                  />
+                ))}
+              </ul>
+            </div>
+
+            <div className="border-t border-[var(--lp-border)] pt-3.5">
+              <p className="text-[12px] font-medium text-[var(--lp-muted)] mb-2">
+                General access
+              </p>
+              <div className="flex items-start gap-2.5">
+                <div className="mt-0.5 shrink-0">
+                  {shared ? (
+                    <Globe className="w-4 h-4 text-[var(--lp-accent)]" />
+                  ) : (
+                    <Link2Off className="w-4 h-4 text-[var(--lp-muted)]" />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[13px] font-medium">
+                    {shared ? "Anyone with the link" : "Restricted"}
+                  </p>
+                  <p className="text-[12px] text-[var(--lp-muted)] mt-0.5">
+                    {shared
+                      ? "Anyone who opens the link can edit this document."
+                      : "Only the people listed above can open this document."}
+                  </p>
+                </div>
+                {isOwner && (
+                  <button
+                    onClick={toggleLink}
+                    disabled={isUpdating}
+                    role="switch"
+                    aria-checked={shared}
+                    aria-label="Anyone with the link can edit"
+                    className={`mt-0.5 shrink-0 h-5 w-9 rounded-full transition-colors disabled:opacity-50 ${
+                      shared
+                        ? "bg-[var(--lp-accent)]"
+                        : "bg-[var(--lp-border)]"
+                    }`}
+                  >
+                    <span
+                      className={`block h-4 w-4 rounded-full bg-white transition-transform ${
+                        shared ? "translate-x-[18px]" : "translate-x-[2px]"
+                      }`}
+                    />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <button
+              onClick={copyLink}
+              disabled={!shared}
+              title={
+                shared
+                  ? undefined
+                  : "Turn on “Anyone with the link” to share a link"
+              }
+              className="inline-flex items-center justify-center gap-1.5 h-9 rounded-md border border-[var(--lp-border)] text-[12.5px] font-medium transition-colors hover:bg-[var(--lp-paper-2)] disabled:opacity-40 disabled:hover:bg-transparent"
+            >
+              <Copy className="w-3.5 h-3.5" />
+              Copy link
+            </button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/writer/[id]/editor/index.ts
+++ b/app/writer/[id]/editor/index.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams } from "next/navigation";
 import { useEditor } from "@tiptap/react";
 import { type Editor as TiptapEditor } from "@tiptap/core";
@@ -30,6 +30,14 @@ type EditorPropType = {
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
+// docId is carried alongside so effects can tell a live session from one that
+// belongs to the document we just navigated away from.
+type CollabSession = {
+  docId: string;
+  ydoc: Y.Doc;
+  provider: WebsocketProvider;
+};
+
 export const Editor = ({ setIsSaving }: EditorPropType) => {
   const params = useParams();
   const docId = params.id as string;
@@ -47,29 +55,32 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
     setName(session.id ? session.name || "" : getGuestUser().name);
   }, [session]);
 
-  // Per-document Yjs collaboration. The room is keyed on the docId, not on
-  // the calendar date, so accounts editing different documents never sync
-  // into each other's content. ydoc + provider are scoped to this docId and
-  // torn down on unmount / navigation to a different doc.
-  // Lifecycle is keyed on docId — eslint doesn't see that the factory body
-  // doesn't reference it because the dependency *is* the identity tag.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const ydoc = useMemo(() => new Y.Doc(), [docId]);
-  const provider = useMemo(
-    () =>
-      new WebsocketProvider(
-        process.env.NEXT_PUBLIC_WEBSOCKET_URL as string,
-        `doc.${docId}`,
-        ydoc,
-      ),
-    [docId, ydoc],
-  );
+  // Per-document Yjs collaboration. The room is keyed on the docId, so
+  // accounts editing different documents never sync into each other's content.
+  //
+  // Creation and teardown must live in the same effect. Building these with
+  // useMemo and destroying them from a separate cleanup breaks under React
+  // strict mode: the component mounts, unmounts and mounts again, the first
+  // cleanup destroys the provider, and useMemo then hands the second mount the
+  // same already-destroyed objects. The socket never syncs and the room stays
+  // empty for everyone.
+  const [collab, setCollab] = useState<CollabSession | null>(null);
+
   useEffect(() => {
+    const ydoc = new Y.Doc();
+    const provider = new WebsocketProvider(
+      process.env.NEXT_PUBLIC_WEBSOCKET_URL as string,
+      `doc.${docId}`,
+      ydoc,
+    );
+    setCollab({ docId, ydoc, provider });
+
     return () => {
       provider.destroy();
       ydoc.destroy();
+      setCollab(null);
     };
-  }, [provider, ydoc]);
+  }, [docId]);
 
   // Save serialization: never run two persists in parallel. If onUpdate fires
   // again while a save is in flight, we just flip `pendingRef` and re-fire
@@ -132,46 +143,81 @@ export const Editor = ({ setIsSaving }: EditorPropType) => {
     };
   }, [debounce]);
 
+  // The Yjs room, not the database row, is the live state once anyone is
+  // connected. Seeding has to wait for sync to finish, or we cannot tell an
+  // empty room from one whose content simply has not arrived yet.
+  const [isSynced, setIsSynced] = useState(false);
+  useEffect(() => {
+    if (!collab) {
+      setIsSynced(false);
+      return;
+    }
+    // Read the current value rather than assuming false: against a fast server
+    // the provider can finish syncing before React commits this effect, and the
+    // event would already have fired with nobody listening.
+    setIsSynced(collab.provider.synced);
+    const onSync = (synced: boolean) => setIsSynced(synced);
+    collab.provider.on("sync", onSync);
+    return () => {
+      collab.provider.off("sync", onSync);
+    };
+  }, [collab]);
+
   const editor = useEditor(
     {
-      onCreate: ({ editor: currentEditor }) => {
-        provider.on("sync", () => {
-          if (currentEditor.isEmpty) {
-            currentEditor.commands.setContent("");
-          }
-        });
-      },
-      extensions: [
-        ...extensions,
-        Collaboration.configure({ document: ydoc }),
-        CollaborationCursor.configure({
-          provider,
-          user: { name, color: getRandomColor() },
-        }),
-      ],
+      extensions: collab
+        ? [
+            ...extensions,
+            Collaboration.configure({ document: collab.ydoc }),
+            CollaborationCursor.configure({
+              provider: collab.provider,
+              user: { name, color: getRandomColor() },
+            }),
+          ]
+        : extensions,
       editorProps: props,
-      content: "",
+      // No `content` here on purpose. With Collaboration the editor's initial
+      // content is written into the shared Y.Doc, so every client that mounts
+      // would apply its own copy. Content comes from the room, or from the
+      // one-time seed below when the room is empty.
       onUpdate({ editor }) {
         debounce(editor);
       },
     },
-    [docId, ydoc, provider],
+    [docId, collab],
   );
 
   useEffect(() => {
-    if (editor) editor.chain().focus().updateUser({ name }).run();
-  }, [editor, name]);
+    // updateUser comes from CollaborationCursor. useEditor rebuilds the editor
+    // one commit after the collaboration session appears, so there is a render
+    // where collab exists but this editor was still built without the cursor
+    // extension — test for the command rather than for the session.
+    if (!editor || typeof editor.commands.updateUser !== "function") return;
+    editor.chain().focus().updateUser({ name }).run();
+  }, [editor, collab, name]);
 
-  // Hydrate the editor once per document from the server payload. Tracking by
-  // docId rather than a plain boolean lets us re-hydrate when navigating to a
-  // different document without wiping in-progress typing on the current one.
+  // Seed the room from the database only when it is genuinely empty. With the
+  // Collaboration extension, setContent is a Yjs transaction rather than a
+  // local assignment: running it against a room that already holds content
+  // appends the stored copy on top of the live one, and every peer that does
+  // it broadcasts another copy. That is the same bug in both directions —
+  // duplicated text, and a peer's stale database payload overwriting edits
+  // that another peer just made.
+  //
+  // Tracking by docId rather than a plain boolean lets us seed again when
+  // navigating to a different document without wiping the current one.
   const hydratedDocRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!editor || !docData) return;
+    if (!editor || !docData || !isSynced) return;
+    if (!collab || collab.docId !== docId) return;
     if (hydratedDocRef.current === docId) return;
-    editor.commands.setContent(docData.data ? JSON.parse(docData.data) : "");
     hydratedDocRef.current = docId;
-  }, [editor, docData, docId]);
+
+    if (collab.ydoc.getXmlFragment("default").length > 0) return;
+    if (!docData.data) return;
+
+    editor.commands.setContent(JSON.parse(docData.data));
+  }, [editor, docData, docId, isSynced, collab]);
 
   return { editor, docData, error, isLoading };
 };

--- a/app/writer/[id]/sharing/actions.ts
+++ b/app/writer/[id]/sharing/actions.ts
@@ -1,0 +1,203 @@
+"use server";
+
+import type { LinkAccess } from "@prisma/client";
+
+import prisma from "@/prisma/prismaClient";
+import getServerSession from "@/lib/customHooks/getServerSession";
+import { resolveDocumentAccess } from "@/lib/documentAccess";
+
+export type SharedUser = {
+  id: string;
+  name: string;
+  email: string;
+  picture: string | null;
+  isOwner: boolean;
+};
+
+export type SharingState = {
+  linkAccess: LinkAccess;
+  isOwner: boolean;
+  people: SharedUser[];
+};
+
+const ownedDocument = async (docId: string, userId: string) =>
+  prisma.document.findFirst({
+    where: { id: docId, userId },
+    select: { id: true },
+  });
+
+export const GetSharing = async (docId: string) => {
+  const session = await getServerSession();
+  if (!session.id) return { success: false, error: "User is not logged in" };
+
+  try {
+    const access = await resolveDocumentAccess(docId, session.id);
+    if (!access) return { success: false, error: "Document does not exist" };
+
+    const ownerId = access.document.userId;
+
+    const members = await prisma.userOnDocument.findMany({
+      where: { documentId: docId },
+      select: {
+        assignedAt: true,
+        user: {
+          select: { id: true, name: true, email: true, picture: true },
+        },
+      },
+      orderBy: { assignedAt: "asc" },
+    });
+
+    // The owner is authoritative from Document.userId, not from membership —
+    // a document created before the join table was populated still has one.
+    const people: SharedUser[] = members.map(({ user }) => ({
+      ...user,
+      isOwner: user.id === ownerId,
+    }));
+    people.sort((a, b) => Number(b.isOwner) - Number(a.isOwner));
+
+    const state: SharingState = {
+      linkAccess: access.document.linkAccess,
+      isOwner: ownerId === session.id,
+      people,
+    };
+    return { success: true, data: state };
+  } catch (e) {
+    console.log(e);
+    return { success: false, error: "Internal server error" };
+  }
+};
+
+// Only the owner can change who reaches the document. Collaborators must not be
+// able to re-share it, or revoking access would be undoable by anyone it was
+// ever leaked to.
+export const SetLinkAccess = async (docId: string, linkAccess: LinkAccess) => {
+  const session = await getServerSession();
+  if (!session.id) return { success: false, error: "User is not logged in" };
+
+  try {
+    if (!(await ownedDocument(docId, session.id)))
+      return { success: false, error: "Only the owner can change sharing" };
+
+    await prisma.document.update({
+      where: { id: docId },
+      data: { linkAccess },
+    });
+
+    return { success: true, data: { linkAccess } };
+  } catch (e) {
+    console.log(e);
+    return { success: false, error: "Internal server error" };
+  }
+};
+
+// Suggestions are deliberately narrow: prefix matches only, a minimum query
+// length, and a small cap. That keeps the picker useful for someone who knows
+// who they are looking for without turning it into a way to page through every
+// account in the app. Owner-only for the same reason.
+const SEARCH_MIN_CHARS = 2;
+const SEARCH_LIMIT = 5;
+
+export const SearchUsers = async (docId: string, query: string) => {
+  const session = await getServerSession();
+  if (!session.id) return { success: false, error: "User is not logged in" };
+
+  const trimmed = query.trim();
+  if (trimmed.length < SEARCH_MIN_CHARS)
+    return { success: true, data: [] as SharedUser[] };
+
+  try {
+    if (!(await ownedDocument(docId, session.id)))
+      return { success: false, error: "Only the owner can add people" };
+
+    const members = await prisma.userOnDocument.findMany({
+      where: { documentId: docId },
+      select: { userId: true },
+    });
+
+    const matches = await prisma.user.findMany({
+      where: {
+        id: { notIn: members.map((m) => m.userId) },
+        OR: [
+          { email: { startsWith: trimmed, mode: "insensitive" } },
+          { name: { startsWith: trimmed, mode: "insensitive" } },
+        ],
+      },
+      select: { id: true, name: true, email: true, picture: true },
+      orderBy: { email: "asc" },
+      take: SEARCH_LIMIT,
+    });
+
+    return {
+      success: true,
+      data: matches.map((user) => ({ ...user, isOwner: false })),
+    };
+  } catch (e) {
+    console.log(e);
+    return { success: false, error: "Internal server error" };
+  }
+};
+
+export const AddCollaborator = async (docId: string, email: string) => {
+  const session = await getServerSession();
+  if (!session.id) return { success: false, error: "User is not logged in" };
+
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return { success: false, error: "Enter an email address" };
+
+  try {
+    if (!(await ownedDocument(docId, session.id)))
+      return { success: false, error: "Only the owner can add people" };
+
+    const user = await prisma.user.findUnique({
+      where: { email: normalized },
+      select: { id: true, name: true, email: true, picture: true },
+    });
+    if (!user)
+      return { success: false, error: "No DocX account with that email" };
+
+    const existing = await prisma.userOnDocument.findUnique({
+      where: { userId_documentId: { userId: user.id, documentId: docId } },
+      select: { userId: true },
+    });
+    if (existing)
+      return { success: false, error: `${user.name} already has access` };
+
+    await prisma.userOnDocument.create({
+      data: { userId: user.id, documentId: docId },
+    });
+
+    return {
+      success: true,
+      data: { ...user, isOwner: false } satisfies SharedUser,
+    };
+  } catch (e) {
+    console.log(e);
+    return { success: false, error: "Internal server error" };
+  }
+};
+
+export const RemoveCollaborator = async (docId: string, userId: string) => {
+  const session = await getServerSession();
+  if (!session.id) return { success: false, error: "User is not logged in" };
+
+  try {
+    const doc = await prisma.document.findFirst({
+      where: { id: docId, userId: session.id },
+      select: { userId: true },
+    });
+    if (!doc)
+      return { success: false, error: "Only the owner can remove people" };
+
+    if (userId === doc.userId)
+      return { success: false, error: "The owner cannot be removed" };
+
+    await prisma.userOnDocument.deleteMany({
+      where: { userId, documentId: docId },
+    });
+
+    return { success: true, data: { userId } };
+  } catch (e) {
+    console.log(e);
+    return { success: false, error: "Internal server error" };
+  }
+};

--- a/lib/documentAccess.ts
+++ b/lib/documentAccess.ts
@@ -1,0 +1,43 @@
+import type { Document } from "@prisma/client";
+
+import prisma from "@/prisma/prismaClient";
+
+// A user may open a document either because they are already a collaborator on
+// it, or because the owner turned on link access. Both the document read and
+// the collaboration token mint have to agree on that rule, so it lives here
+// rather than being spelled out at each call site.
+
+export type DocumentAccess = {
+  document: Document;
+  isMember: boolean;
+};
+
+export const resolveDocumentAccess = async (
+  docId: string,
+  userId: string,
+): Promise<DocumentAccess | null> => {
+  const found = await prisma.document.findUnique({
+    where: { id: docId },
+    include: { users: { where: { userId }, select: { userId: true } } },
+  });
+  if (!found) return null;
+
+  const { users, ...document } = found;
+  const isMember = users.length > 0;
+
+  if (!isMember && document.linkAccess === "NONE") return null;
+
+  return { document, isMember };
+};
+
+// Opening a link-shared document makes the caller a collaborator, which is what
+// puts it on their dashboard and their avatar in the header. Membership granted
+// this way outlives the link: revoking link access does not remove people who
+// already joined, so removing someone stays an explicit action.
+export const joinViaLink = async (docId: string, userId: string) => {
+  await prisma.userOnDocument.upsert({
+    where: { userId_documentId: { userId, documentId: docId } },
+    create: { userId, documentId: docId },
+    update: {},
+  });
+};

--- a/lib/guestServices.ts
+++ b/lib/guestServices.ts
@@ -42,7 +42,8 @@ export const createGuestDocument = (initialData?: string) => {
     // Guest documents never reach the server, so they are never indexed.
     indexedHash: null,
     thumbnail: null,
-    deleteUrl: null
+    deleteUrl: null,
+    linkAccess: "NONE"
   }
 
   const allDocuments: Document[] = JSON.parse(localStorage.getItem('documents') || '[]');

--- a/prisma/migrations/20260816090000_link_access/migration.sql
+++ b/prisma/migrations/20260816090000_link_access/migration.sql
@@ -1,0 +1,10 @@
+CREATE TYPE "LinkAccess" AS ENUM ('NONE', 'EDIT');
+
+ALTER TABLE "Document" ADD COLUMN "linkAccess" "LinkAccess" NOT NULL DEFAULT 'NONE';
+
+-- Documents that predate this column were reachable by anyone holding their
+-- link, because opening one joined the caller as a collaborator. Defaulting
+-- them to NONE would silently break links already shared with other people,
+-- so existing rows keep the access they effectively had. New documents are
+-- private until explicitly shared.
+UPDATE "Document" SET "linkAccess" = 'EDIT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,14 @@ model User {
   aiUsage     AiUsage[]
 }
 
+/// Who can open a document without already being a collaborator on it.
+/// `NONE` means the id alone grants nothing; `EDIT` means anyone holding the
+/// link may open and edit, and joins as a collaborator when they do.
+enum LinkAccess {
+  NONE
+  EDIT
+}
+
 model Document {
   id        String   @id @default(uuid())
   name      String   @default("Untitled Document")
@@ -41,6 +49,8 @@ model Document {
   createdBy User     @relation(fields: [userId], references: [id], name: "CreatedDocuments")
   thumbnail String?
   deleteUrl String?
+
+  linkAccess LinkAccess @default(NONE)
 
   // Hash of `data` as of the last fully successful index. A mismatch against
   // the current data means the chunks are stale — indexing failed, or the


### PR DESCRIPTION
Restores link sharing, adds a proper share dialog, and fixes the Yjs collaboration lifecycle.

## Link sharing was broken on main

#64 changed `GetDocDetails` to require existing membership, on the grounds that opening a document should not grant access to it. That reasoning was right about the mechanism and wrong about the product: auto-join *was* the sharing feature. The Share button only ever copied the URL, so with membership required, a recipient got "This document doesn't exist or you don't have access."

The real problem was not that a link grants access — it is that every document was link-shared from birth, permanently, with no way to tell a deliberate share from a leak and no way to turn it off.

`Document.linkAccess` (`NONE` | `EDIT`) makes it explicit. A caller may open a document when they are already a collaborator **or** when link access is on; opening a link-shared document joins them, which is what puts it on their dashboard. Anyone else gets the same answer as for a document that does not exist, so ids cannot be probed.

Existing documents are backfilled to `EDIT` so links already sent to people keep working. New documents default to `NONE`.

## Share dialog

Two independent ways to share, as in Google Docs:

- **By person** — search by name or email, add as an editor. Suggestions are prefix-only, minimum two characters, capped at five, and exclude people already on the document, so this does not become a way to page through every account.
- **By link** — a *General access* switch. Copy link is disabled while access is `Restricted`, so a link can only be handed out after the switch is deliberately turned on.

Adding, removing and flipping the switch are owner-only. Collaborators must not be able to re-share, or revoking would be undoable by anyone the link ever leaked to. Turning link access off blocks new joins but does not remove people who already joined — that stays an explicit action.

The dashboard card's Share now refuses to copy a link that grants nothing, instead of silently producing a dead one.

## Yjs collaboration lifecycle

Collaboration was broken in three overlapping ways, all from one root cause.

`ydoc` and the `WebsocketProvider` were built in `useMemo` and destroyed from a separate cleanup effect. `reactStrictMode` defaults to true, so React mounts, unmounts and mounts again — the first cleanup destroyed the provider, and `useMemo` handed the second mount the same dead objects. The socket never synced and the room stayed empty.

Reproduced against a local instance of the collaboration server:

```
mount 1  synced: true
after cleanup   synced: false
server room content: (EMPTY)
```

Creation and teardown now live in the same effect, keyed on `docId`, with the session held in state, so a strict-mode remount builds a fresh `Y.Doc` and provider.

Two related defects fixed alongside it, both of which were previously masked:

- `content: ""` was passed to `useEditor`. With `Collaboration`, initial content is written into the shared `Y.Doc`, so every client that mounted applied its own copy.
- The database payload was seeded into the editor unconditionally. `setContent` under `Collaboration` is a Yjs transaction, not a local assignment, so seeding into a populated room appended a second copy of the stored text, and a peer's stale payload could overwrite edits another peer had just made. Seeding now waits for sync and only runs when the room is genuinely empty.

Verified with two real peers against the collaboration server: content stored once, live edits propagating.

## Verified

- Migration applied to Neon; 57 existing documents backfilled to `EDIT`
- Access rule exercised directly: member/link-shared/restricted/missing all resolve correctly
- Add, list and remove collaborators; unknown email rejected
- Search: minimum length, case-insensitivity, cap, and exclusion of existing members
- `tsc --noEmit` clean, `next lint` clean

## Not covered

The collaboration server is still unauthenticated. Anyone who knows a document id can join room `doc.<id>` over the WebSocket and read and write live content regardless of `linkAccess`. Closing that needs a signed room token and a change to the separate `docx-websocket-server` repo; `resolveDocumentAccess` is the predicate the token mint will use.
