### PR TITLE
feat: import documents from Google Docs

### DIFF
--- a/app/document/components/Header/actions.ts
+++ b/app/document/components/Header/actions.ts
@@ -45,7 +45,10 @@ export const SearchDocAction = async (value: string) => {
   }
 };
 
-export const CreateNewDocument = async (initialData?: string) => {
+export const CreateNewDocument = async (
+  initialData?: string,
+  name?: string,
+) => {
   try {
     const session = await getServerSession();
     if (!session.id)
@@ -57,6 +60,8 @@ export const CreateNewDocument = async (initialData?: string) => {
     const doc = await prisma.document.create({
       data: {
         data: initialData ?? "",
+        // Left unset when absent so the schema default applies.
+        ...(name?.trim() ? { name: name.trim() } : {}),
         userId: session.id,
         users: {
           create: {

--- a/app/document/components/ImportGoogleDoc.tsx
+++ b/app/document/components/ImportGoogleDoc.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import useClientSession from "@/lib/customHooks/useClientSession";
+import {
+  isPickerConfigured,
+  pickGoogleDocument,
+  preloadGooglePicker,
+} from "@/lib/googleDocs/picker";
+import { fetchGoogleDocument } from "@/lib/googleDocs/fetchDocument";
+import { toTiptap, type DroppedContent } from "@/lib/googleDocs/toTiptap";
+import { ImportDocument } from "../import/actions";
+import { IndexDocument } from "@/app/writer/[id]/rag/actions";
+
+const plural = (count: number, noun: string) =>
+  `${count} ${noun}${count === 1 ? "" : "s"}`;
+
+/**
+ * The editor has no node for tables or images, so they are lost on import.
+ * Saying so beats letting someone discover it in a document they trusted.
+ */
+const describeDropped = ({ tables, images }: DroppedContent) => {
+  const parts: string[] = [];
+  if (tables > 0) parts.push(plural(tables, "table"));
+  if (images > 0) parts.push(plural(images, "image"));
+  if (parts.length === 0) return null;
+  return `${parts.join(" and ")} could not be imported`;
+};
+
+export default function ImportGoogleDoc() {
+  const router = useRouter();
+  const session = useClientSession();
+  const [isImporting, setIsImporting] = useState(false);
+
+  if (!isPickerConfigured()) return null;
+
+  const handleClick = async () => {
+    if (isImporting) return;
+
+    if (!session?.id) {
+      toast.error("Sign in to import from Google Docs");
+      return;
+    }
+
+    setIsImporting(true);
+    try {
+      const picked = await pickGoogleDocument();
+      if (!picked) return;
+
+      const source = await fetchGoogleDocument(picked.file.id, picked.token);
+      const { doc, dropped } = toTiptap(source);
+
+      const response = await ImportDocument(
+        picked.file.name,
+        JSON.stringify(doc),
+      );
+      if (!response.success || !response.data) {
+        toast.error(response.error);
+        return;
+      }
+
+      // Not awaited, matching the editor: embedding takes seconds and the
+      // document is already saved. A dropped call is retried by the next
+      // snapshot, since indexedHash still disagrees with the content.
+      IndexDocument(response.data.id).catch(() => {});
+
+      const lost = describeDropped(dropped);
+      toast.success(
+        lost ? `Imported — ${lost}` : `Imported “${picked.file.name}”`,
+      );
+      router.push(`/writer/${response.data.id}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Import failed");
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      onPointerEnter={preloadGooglePicker}
+      onFocus={preloadGooglePicker}
+      disabled={isImporting}
+      className="inline-flex items-center gap-1.5 h-8 px-3 rounded-md border border-[var(--lp-border)] bg-[var(--lp-card)] text-[12.5px] font-medium text-[var(--lp-ink)] transition-colors hover:border-[var(--lp-accent)] disabled:opacity-50"
+    >
+      {isImporting ? (
+        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+      ) : (
+        <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" aria-hidden>
+          <path fill="#4285F4" d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <path fill="#A1C2FA" d="M14 2v6h6z" />
+        </svg>
+      )}
+      {isImporting ? "Importing…" : "Import from Google Docs"}
+    </button>
+  );
+}

--- a/app/document/components/QuickStart.tsx
+++ b/app/document/components/QuickStart.tsx
@@ -1,6 +1,7 @@
 import DocThumbnail from "@/components/DocThumbnail";
 import { TEMPLATES } from "@/lib/templates";
 import NewDocButton from "./NewDocButton";
+import ImportGoogleDoc from "./ImportGoogleDoc";
 
 export default function QuickStart() {
   return (
@@ -14,6 +15,7 @@ export default function QuickStart() {
             Pick a template
           </h2>
         </div>
+        <ImportGoogleDoc />
       </div>
 
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">

--- a/app/document/import/actions.ts
+++ b/app/document/import/actions.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { CreateNewDocument } from "../components/Header/actions";
+import { CreateDocVersion } from "@/app/writer/[id]/versions/actions";
+
+/**
+ * Creates a document from content converted in the browser.
+ *
+ * A version snapshot is written straight away so history has an "as imported"
+ * baseline to restore to. Indexing is deliberately left to the caller: it takes
+ * seconds, and work started but not awaited inside a server action is not
+ * guaranteed to survive the response on a serverless host.
+ */
+export const ImportDocument = async (name: string, data: string) => {
+  const created = await CreateNewDocument(data, name);
+  if (!created.success || !created.data) return created;
+
+  await CreateDocVersion(created.data.id, data);
+
+  return created;
+};

--- a/app/writer/[id]/editor/editorConfig.ts
+++ b/app/writer/[id]/editor/editorConfig.ts
@@ -1,6 +1,7 @@
 import { Color } from "@tiptap/extension-color";
 import StarterKit from "@tiptap/starter-kit";
 import Highlight from "@tiptap/extension-highlight";
+import Link from "@tiptap/extension-link";
 import Underline from "@tiptap/extension-underline";
 import TextAlign from "@tiptap/extension-text-align";
 import FontFamily from "@tiptap/extension-font-family";
@@ -17,6 +18,10 @@ export const extensions = [
   }),
   Color.configure({ types: [TextStyle.name] }),
   Highlight.configure({ multicolor: true }),
+  // Imported documents carry hyperlinks; without this mark they would arrive
+  // as plain text. openOnClick stays off so a click places the caret instead
+  // of navigating away mid-edit.
+  Link.configure({ openOnClick: false, autolink: false }),
   Underline,
   TextStyle,
   FontFamily,

--- a/lib/googleDocs/fetchDocument.ts
+++ b/lib/googleDocs/fetchDocument.ts
@@ -1,0 +1,29 @@
+import type { GoogleDoc } from "./types";
+
+const DOCS_ENDPOINT = "https://docs.googleapis.com/v1/documents";
+
+export class GoogleDocsFetchError extends Error {}
+
+/**
+ * Reads a document the user granted through the picker.
+ *
+ * The Docs API honours the `drive.file` scope for picker-granted files, so the
+ * native document structure is reachable without asking for a restricted scope
+ * such as `drive.readonly`.
+ */
+export const fetchGoogleDocument = async (fileId: string, token: string) => {
+  const response = await fetch(`${DOCS_ENDPOINT}/${fileId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (response.status === 401 || response.status === 403)
+    throw new GoogleDocsFetchError("Google denied access to that document");
+
+  if (response.status === 404)
+    throw new GoogleDocsFetchError("That document could not be found");
+
+  if (!response.ok)
+    throw new GoogleDocsFetchError("Google could not return that document");
+
+  return (await response.json()) as GoogleDoc;
+};

--- a/lib/googleDocs/picker.ts
+++ b/lib/googleDocs/picker.ts
@@ -1,0 +1,206 @@
+/**
+ * Browser-side Google Drive picker.
+ *
+ * The access token never leaves the browser and is never persisted. Import is
+ * an on-demand action, so there is nothing to do in the background and no
+ * reason to hold a refresh token — which also keeps the app out of Google's
+ * restricted-scope review, since `drive.file` only ever grants access to the
+ * exact files a user hands over through this picker.
+ */
+
+const SCOPE = "https://www.googleapis.com/auth/drive.file";
+const DOCS_MIME_TYPE = "application/vnd.google-apps.document";
+
+export type PickedDocument = {
+  id: string;
+  name: string;
+};
+
+type TokenResponse = {
+  access_token?: string;
+  expires_in?: number;
+  error?: string;
+};
+
+type TokenClient = {
+  callback: (response: TokenResponse) => void;
+  requestAccessToken: (overrides?: { prompt?: string }) => void;
+};
+
+type PickerBuilder = {
+  addView: (view: unknown) => PickerBuilder;
+  setOAuthToken: (token: string) => PickerBuilder;
+  setDeveloperKey: (key: string) => PickerBuilder;
+  setAppId: (appId: string) => PickerBuilder;
+  setTitle: (title: string) => PickerBuilder;
+  setCallback: (callback: (data: PickerCallbackData) => void) => PickerBuilder;
+  build: () => { setVisible: (visible: boolean) => void };
+};
+
+type PickerCallbackData = {
+  action?: string;
+  docs?: { id: string; name: string }[];
+};
+
+type GoogleGlobal = {
+  accounts: {
+    oauth2: {
+      initTokenClient: (config: {
+        client_id: string;
+        scope: string;
+        callback: (response: TokenResponse) => void;
+      }) => TokenClient;
+    };
+  };
+  picker: {
+    PickerBuilder: new () => PickerBuilder;
+    DocsView: new (viewId?: string) => {
+      setMimeTypes: (types: string) => unknown;
+    };
+    ViewId: { DOCS: string };
+    Action: { PICKED: string; CANCEL: string };
+  };
+};
+
+declare global {
+  interface Window {
+    google?: GoogleGlobal;
+    gapi?: { load: (name: string, callback: () => void) => void };
+  }
+}
+
+export class GooglePickerError extends Error {}
+
+const config = () => {
+  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+  const developerKey = process.env.NEXT_PUBLIC_GOOGLE_PICKER_KEY;
+  const appId = process.env.NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER;
+
+  if (!clientId || !developerKey || !appId)
+    throw new GooglePickerError("Google import is not configured");
+
+  return { clientId, developerKey, appId };
+};
+
+export const isPickerConfigured = () =>
+  Boolean(
+    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID &&
+      process.env.NEXT_PUBLIC_GOOGLE_PICKER_KEY &&
+      process.env.NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER,
+  );
+
+const loading = new Map<string, Promise<void>>();
+
+// Loaded on first use rather than from the layout, so Google's scripts are not
+// pulled into every page for a feature most visits never touch.
+const loadScript = (src: string) => {
+  const pending = loading.get(src);
+  if (pending) return pending;
+
+  const promise = new Promise<void>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      loading.delete(src);
+      reject(new GooglePickerError("Could not reach Google"));
+    };
+    document.body.appendChild(script);
+  });
+
+  loading.set(src, promise);
+  return promise;
+};
+
+const loadPickerApi = async () => {
+  await loadScript("https://apis.google.com/js/api.js");
+  await new Promise<void>((resolve) => window.gapi?.load("picker", resolve));
+};
+
+/**
+ * Warms both Google scripts ahead of the click. Google's consent popup is
+ * opened from a user gesture, and a gesture does not survive waiting on a
+ * network request, so the scripts have to already be there when the handler
+ * runs. Called on hover and focus rather than on mount, to keep Google's code
+ * off dashboard visits that never import anything.
+ */
+export const preloadGooglePicker = () => {
+  if (!isPickerConfigured()) return;
+  loadScript("https://accounts.google.com/gsi/client").catch(() => {});
+  loadPickerApi().catch(() => {});
+};
+
+let cachedToken: { value: string; expiresAt: number } | null = null;
+
+const requestToken = async () => {
+  if (cachedToken && cachedToken.expiresAt > Date.now()) return cachedToken.value;
+
+  await loadScript("https://accounts.google.com/gsi/client");
+  const { clientId } = config();
+
+  return new Promise<string>((resolve, reject) => {
+    const client = window.google?.accounts.oauth2.initTokenClient({
+      client_id: clientId,
+      scope: SCOPE,
+      callback: (response) => {
+        if (!response.access_token) {
+          reject(new GooglePickerError(response.error ?? "Access was denied"));
+          return;
+        }
+        // A minute of headroom so a token cannot expire between the picker
+        // handing back a file and the document fetch that follows.
+        cachedToken = {
+          value: response.access_token,
+          expiresAt: Date.now() + ((response.expires_in ?? 3600) - 60) * 1000,
+        };
+        resolve(response.access_token);
+      },
+    });
+
+    if (!client) {
+      reject(new GooglePickerError("Could not reach Google"));
+      return;
+    }
+    client.requestAccessToken();
+  });
+};
+
+const showPicker = (token: string) => {
+  const { developerKey, appId } = config();
+  const picker = window.google?.picker;
+  if (!picker) throw new GooglePickerError("Could not reach Google");
+
+  return new Promise<PickedDocument | null>((resolve) => {
+    const view = new picker.DocsView(picker.ViewId.DOCS);
+    view.setMimeTypes(DOCS_MIME_TYPE);
+
+    new picker.PickerBuilder()
+      .addView(view)
+      .setOAuthToken(token)
+      .setDeveloperKey(developerKey)
+      .setAppId(appId)
+      .setTitle("Choose a document to import")
+      .setCallback((data) => {
+        if (data.action === picker.Action.CANCEL) resolve(null);
+        if (data.action !== picker.Action.PICKED) return;
+
+        const [file] = data.docs ?? [];
+        resolve(file ? { id: file.id, name: file.name } : null);
+      })
+      .build()
+      .setVisible(true);
+  });
+};
+
+/**
+ * Resolves to the file the user chose, or null when they dismissed the picker.
+ * The token is returned alongside because it is the only thing authorising the
+ * document fetch that follows, and it is deliberately held nowhere else.
+ */
+export const pickGoogleDocument = async () => {
+  const token = await requestToken();
+  await loadPickerApi();
+  const file = await showPicker(token);
+  return file ? { file, token } : null;
+};

--- a/lib/googleDocs/toTiptap.ts
+++ b/lib/googleDocs/toTiptap.ts
@@ -1,0 +1,291 @@
+import type {
+  Alignment,
+  GoogleDoc,
+  NamedStyleType,
+  Paragraph,
+  RgbColor,
+  StructuralElement,
+  TextStyle,
+} from "./types";
+
+export type TiptapMark = {
+  type: string;
+  attrs?: Record<string, unknown>;
+};
+
+export type TiptapNode = {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: TiptapNode[];
+  marks?: TiptapMark[];
+  text?: string;
+};
+
+/**
+ * Content the editor has no node for. Reported to the user after an import
+ * rather than dropped in silence.
+ */
+export type DroppedContent = {
+  tables: number;
+  images: number;
+};
+
+export type ImportResult = {
+  doc: TiptapNode;
+  dropped: DroppedContent;
+};
+
+const HEADING_LEVELS: Partial<Record<NamedStyleType, number>> = {
+  TITLE: 1,
+  SUBTITLE: 2,
+  HEADING_1: 1,
+  HEADING_2: 2,
+  HEADING_3: 3,
+  HEADING_4: 4,
+  HEADING_5: 5,
+  HEADING_6: 6,
+};
+
+const TEXT_ALIGN: Partial<Record<Alignment, string>> = {
+  CENTER: "center",
+  END: "right",
+  JUSTIFIED: "justify",
+};
+
+const toHex = (rgb: RgbColor | undefined) => {
+  if (!rgb) return null;
+  const channel = (value: number | undefined) =>
+    Math.round(Math.max(0, Math.min(1, value ?? 0)) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${channel(rgb.red)}${channel(rgb.green)}${channel(rgb.blue)}`;
+};
+
+const foregroundOf = (style: TextStyle | undefined) =>
+  toHex(style?.foregroundColor?.color?.rgbColor);
+
+const fontOf = (style: TextStyle | undefined) =>
+  style?.weightedFontFamily?.fontFamily ?? null;
+
+/**
+ * Google writes an explicit colour and font family onto nearly every run,
+ * usually the document default. Emitting those verbatim would pin imported
+ * text to black and to Arial, which fights the app's own theme and dark mode.
+ * Comparing against the NORMAL_TEXT named style keeps only what the author
+ * actually changed.
+ */
+const marksFor = (style: TextStyle | undefined, baseline: TextStyle | undefined) => {
+  const marks: TiptapMark[] = [];
+  if (!style) return marks;
+
+  if (style.bold) marks.push({ type: "bold" });
+  if (style.italic) marks.push({ type: "italic" });
+  if (style.underline && !style.link) marks.push({ type: "underline" });
+  if (style.strikethrough) marks.push({ type: "strike" });
+
+  const href = style.link?.url;
+  if (href) marks.push({ type: "link", attrs: { href } });
+
+  const textStyleAttrs: Record<string, unknown> = {};
+
+  const color = foregroundOf(style);
+  if (color && color !== foregroundOf(baseline)) textStyleAttrs.color = color;
+
+  const fontFamily = fontOf(style);
+  if (fontFamily && fontFamily !== fontOf(baseline))
+    textStyleAttrs.fontFamily = fontFamily;
+
+  if (Object.keys(textStyleAttrs).length > 0)
+    marks.push({ type: "textStyle", attrs: textStyleAttrs });
+
+  const highlight = toHex(style.backgroundColor?.color?.rgbColor);
+  if (highlight && highlight !== "#ffffff")
+    marks.push({ type: "highlight", attrs: { color: highlight } });
+
+  return marks;
+};
+
+/**
+ * Within a paragraph Google encodes a soft line break as a vertical tab and
+ * terminates the paragraph itself with a newline. The newline is structural
+ * and already expressed by the block boundary, so only the vertical tab
+ * becomes a node.
+ */
+const runToNodes = (text: string, marks: TiptapMark[]) => {
+  const nodes: TiptapNode[] = [];
+  const segments = text.replace(/\n/g, "").split("\v");
+
+  segments.forEach((segment, index) => {
+    if (index > 0) nodes.push({ type: "hardBreak" });
+    if (segment.length === 0) return;
+    nodes.push(
+      marks.length > 0
+        ? { type: "text", text: segment, marks }
+        : { type: "text", text: segment },
+    );
+  });
+
+  return nodes;
+};
+
+type ListPosition = {
+  listId: string;
+  level: number;
+  ordered: boolean;
+};
+
+type Block = {
+  node: TiptapNode;
+  list: ListPosition | null;
+};
+
+const paragraphToBlock = (
+  paragraph: Paragraph,
+  source: GoogleDoc,
+  baseline: TextStyle | undefined,
+  dropped: DroppedContent,
+): Block | null => {
+  const content: TiptapNode[] = [];
+  let isHorizontalRule = false;
+
+  for (const element of paragraph.elements ?? []) {
+    if (element.horizontalRule) {
+      isHorizontalRule = true;
+      continue;
+    }
+    if (element.inlineObjectElement) {
+      dropped.images += 1;
+      continue;
+    }
+    if (!element.textRun?.content) continue;
+
+    content.push(
+      ...runToNodes(
+        element.textRun.content,
+        marksFor(element.textRun.textStyle, baseline),
+      ),
+    );
+  }
+
+  if (isHorizontalRule) return { node: { type: "horizontalRule" }, list: null };
+
+  const bullet = paragraph.bullet;
+  const level = bullet?.nestingLevel ?? 0;
+  const glyph = bullet?.listId
+    ? source.lists?.[bullet.listId]?.listProperties?.nestingLevels?.[level]
+    : undefined;
+
+  const list: ListPosition | null = bullet?.listId
+    ? {
+        listId: bullet.listId,
+        level,
+        ordered: Boolean(glyph?.glyphType) && !glyph?.glyphSymbol,
+      }
+    : null;
+
+  // List items hold paragraphs, so a heading style inside a list is ignored.
+  const headingLevel = list
+    ? undefined
+    : HEADING_LEVELS[paragraph.paragraphStyle?.namedStyleType ?? "NORMAL_TEXT"];
+
+  const attrs: Record<string, unknown> = {};
+  if (headingLevel) attrs.level = headingLevel;
+
+  const align = TEXT_ALIGN[paragraph.paragraphStyle?.alignment ?? "START"];
+  if (align) attrs.textAlign = align;
+
+  const node: TiptapNode = {
+    type: headingLevel ? "heading" : "paragraph",
+  };
+  if (Object.keys(attrs).length > 0) node.attrs = attrs;
+  if (content.length > 0) node.content = content;
+
+  return { node, list };
+};
+
+/**
+ * Google reports list membership per paragraph as a flat (listId, nestingLevel)
+ * pair. Tiptap needs the tree, so consecutive members of the same list are
+ * folded back into nested bulletList/orderedList nodes with a level stack.
+ */
+const nestLists = (blocks: Block[]) => {
+  const content: TiptapNode[] = [];
+  let stack: { level: number; node: TiptapNode }[] = [];
+  let currentListId: string | null = null;
+
+  for (const block of blocks) {
+    if (!block.list) {
+      stack = [];
+      currentListId = null;
+      content.push(block.node);
+      continue;
+    }
+
+    if (block.list.listId !== currentListId) {
+      stack = [];
+      currentListId = block.list.listId;
+    }
+
+    while (stack.length > 0 && stack[stack.length - 1].level > block.list.level)
+      stack.pop();
+
+    if (stack.length === 0 || stack[stack.length - 1].level < block.list.level) {
+      const listNode: TiptapNode = {
+        type: block.list.ordered ? "orderedList" : "bulletList",
+        content: [],
+      };
+
+      const parent = stack[stack.length - 1]?.node;
+      if (!parent) {
+        content.push(listNode);
+      } else {
+        const lastItem = parent.content?.[parent.content.length - 1];
+        if (lastItem) {
+          lastItem.content = [...(lastItem.content ?? []), listNode];
+        } else {
+          parent.content = [{ type: "listItem", content: [listNode] }];
+        }
+      }
+
+      stack.push({ level: block.list.level, node: listNode });
+    }
+
+    const list = stack[stack.length - 1].node;
+    list.content = [
+      ...(list.content ?? []),
+      { type: "listItem", content: [block.node] },
+    ];
+  }
+
+  return content;
+};
+
+export const toTiptap = (source: GoogleDoc): ImportResult => {
+  const dropped: DroppedContent = { tables: 0, images: 0 };
+  const baseline = source.namedStyles?.styles?.find(
+    (style) => style.namedStyleType === "NORMAL_TEXT",
+  )?.textStyle;
+
+  const blocks: Block[] = [];
+
+  for (const element of source.body?.content ?? ([] as StructuralElement[])) {
+    if (element.table) {
+      dropped.tables += 1;
+      continue;
+    }
+    if (!element.paragraph) continue;
+
+    const block = paragraphToBlock(element.paragraph, source, baseline, dropped);
+    if (block) blocks.push(block);
+  }
+
+  const content = nestLists(blocks);
+
+  return {
+    doc: {
+      type: "doc",
+      content: content.length > 0 ? content : [{ type: "paragraph" }],
+    },
+    dropped,
+  };
+};

--- a/lib/googleDocs/types.ts
+++ b/lib/googleDocs/types.ts
@@ -1,0 +1,113 @@
+/**
+ * The slice of the Google Docs API `documents.get` response this app reads.
+ *
+ * Hand-written rather than pulled from `googleapis`: the full package is a
+ * server-side client with a very large type surface, and the import runs
+ * entirely in the browser against a single REST endpoint. Only the fields the
+ * mapper consumes are declared, so anything Google adds is simply ignored.
+ *
+ * Reference: https://developers.google.com/docs/api/reference/rest/v1/documents
+ */
+
+export type RgbColor = {
+  red?: number;
+  green?: number;
+  blue?: number;
+};
+
+export type OptionalColor = {
+  color?: { rgbColor?: RgbColor };
+};
+
+export type TextStyle = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  foregroundColor?: OptionalColor;
+  backgroundColor?: OptionalColor;
+  weightedFontFamily?: { fontFamily?: string };
+  link?: { url?: string };
+};
+
+export type NamedStyleType =
+  | "TITLE"
+  | "SUBTITLE"
+  | "HEADING_1"
+  | "HEADING_2"
+  | "HEADING_3"
+  | "HEADING_4"
+  | "HEADING_5"
+  | "HEADING_6"
+  | "NORMAL_TEXT"
+  | "NAMED_STYLE_TYPE_UNSPECIFIED";
+
+export type Alignment =
+  | "START"
+  | "CENTER"
+  | "END"
+  | "JUSTIFIED"
+  | "ALIGNMENT_UNSPECIFIED";
+
+export type ParagraphStyle = {
+  namedStyleType?: NamedStyleType;
+  alignment?: Alignment;
+};
+
+export type TextRun = {
+  content?: string;
+  textStyle?: TextStyle;
+};
+
+export type ParagraphElement = {
+  textRun?: TextRun;
+  inlineObjectElement?: { inlineObjectId?: string };
+  horizontalRule?: object;
+  pageBreak?: object;
+  columnBreak?: object;
+  footnoteReference?: object;
+};
+
+export type Bullet = {
+  listId?: string;
+  nestingLevel?: number;
+};
+
+export type Paragraph = {
+  elements?: ParagraphElement[];
+  paragraphStyle?: ParagraphStyle;
+  bullet?: Bullet;
+};
+
+export type StructuralElement = {
+  paragraph?: Paragraph;
+  table?: object;
+  tableOfContents?: object;
+  sectionBreak?: object;
+};
+
+/**
+ * A level's glyph tells ordered from unordered apart: numbered levels carry
+ * `glyphType` (DECIMAL, UPPER_ALPHA, ...) while bulleted levels carry a
+ * literal `glyphSymbol` such as "●".
+ */
+export type NestingLevel = {
+  glyphType?: string;
+  glyphSymbol?: string;
+};
+
+export type List = {
+  listProperties?: { nestingLevels?: NestingLevel[] };
+};
+
+export type NamedStyle = {
+  namedStyleType?: NamedStyleType;
+  textStyle?: TextStyle;
+};
+
+export type GoogleDoc = {
+  title?: string;
+  body?: { content?: StructuralElement[] };
+  lists?: Record<string, List>;
+  namedStyles?: { styles?: NamedStyle[] };
+};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@tiptap/extension-document": "^2.4.0",
     "@tiptap/extension-font-family": "^2.4.0",
     "@tiptap/extension-highlight": "^2.4.0",
+    "@tiptap/extension-link": "^2.27.2",
     "@tiptap/extension-list-item": "^2.4.0",
     "@tiptap/extension-text-align": "^2.4.0",
     "@tiptap/extension-text-style": "^2.4.0",


### PR DESCRIPTION
Imports a Google Doc as a new Docx document, via Google's own file picker.

## Scope

Import only — one direction, on demand. No write-back, no ongoing link between the two documents, no background jobs.

That is a deliberate ceiling rather than a first step toward two-way sync. Google retired the Realtime API in 2019; what remains is `documents.batchUpdate` with `revisionId` optimistic concurrency, plus Drive push notifications that say *a file changed* without saying what. Any "live" Google Docs sync is therefore poll-and-reconcile, and reconciling that against a Yjs room — which has no concept of an external writer — is where documents get lost. Import has none of those problems.

## No OAuth verification, no stored tokens

The scope is `drive.file`, which is non-sensitive: no security assessment, no annual review, no 100-test-user cap. It only ever grants access to files the user hands over through the Google Picker, which is exactly the interaction being built.

The access token is obtained in the browser by Google Identity Services, lives in a module-scoped variable for its hour, and is never sent to the server or written anywhere. Import is a button press, so there is no background work to authorise later and no reason to hold a refresh token — which in turn means no new table, no encryption-at-rest question, and no revocation handling.

## Conversion

`documents.get` returns Google's native structure, and it maps close to one-to-one onto the extensions already configured in `editorConfig.ts`: `namedStyleType` to headings, `bullet.listId` + `nestingLevel` to lists, `paragraphStyle.alignment` to `textAlign`, `textStyle` to marks.

The alternatives were worse for this codebase. Exporting `text/html` sounds like it would let Tiptap's own `parseHTML` do the work, but Google's HTML export puts all styling in a `<style>` block of CSS classes, so the parser sees unstyled spans unless a CSS inliner runs first. Exporting `text/markdown` is by far the least code, but cannot express colour, highlight, font family or alignment — four of the things this editor actually supports.

`lib/googleDocs/types.ts` declares only the fields the mapper reads, rather than adding `googleapis`: the import runs in the browser against a single REST endpoint, and the full server-side client is a large dependency to carry for one GET.

Two details that are not obvious from the API docs:

**Styles are diffed against the document default.** Google stamps an explicit foreground colour and font family onto nearly every run, usually just the document default. Emitting those verbatim pins imported text to `#000000` and Arial, which fights the theme tokens and breaks dark mode outright. The mapper compares each run against the `NORMAL_TEXT` named style and keeps only what the author actually changed.

**Scripts are warmed on hover, not on mount.** Google's consent popup must be opened from a live user gesture, and a gesture does not survive awaiting a script download — clicking cold would get the popup blocked. `onPointerEnter`/`onFocus` preloads both scripts so the click handler finds them ready, which also keeps Google's code off dashboard visits that never import.

## Where imports land

Always a new document, created from the dashboard. A fresh `docId` means an empty Yjs room, so the existing seeding effect hydrates it through the path repaired in #66 — no new collaboration code, and no risk to that fix.

Importing into an already-open document was rejected for now: `setContent` under the `Collaboration` extension is a broadcast Yjs transaction, so it would rewrite live content underneath any connected peer. That needs its own confirm-and-broadcast design.

A version snapshot is written on arrival, so history has an "as imported" baseline. Indexing is fired from the client rather than inside the server action, because work started but not awaited in a server action is not guaranteed to survive the response on a serverless host. Without it, a document that is imported and never typed into would stay invisible to the chat feature.

## Fidelity

`@tiptap/extension-link` is added, so hyperlinks survive. Links are the most common thing in a real document and the loss users notice first.

Tables and images are dropped — there is no Tiptap node for them here, whatever the conversion path. They are counted and reported: *"Imported — 3 tables and 2 images could not be imported"*. Footnotes, equations and page breaks go the same way, silently, as they have no plausible representation at all.

Adding Table and Image extensions would fix this properly, but each is a substantial editor feature in its own right — toolbar controls, resize handles, an upload pipeline, and collaboration behaviour for table cells — and belongs in its own change.

## Verified

The fixture in the scratchpad covers title/subtitle/headings, default-styled text, centred text, bold + coloured + linked runs in one paragraph, a soft line break, two-level bullet nesting, a separate ordered list, a horizontal rule, a table and an inline image.

Mapper output was then round-tripped through the real editor schema, Link mark included:

```
schema check: PASS
text: "Doc title\nHeading two\nPlain default text\nCentred\nbold red linked\nsoftbreak\ntop a\nnested a\nnested b\ntop b\none\ntwo\nafter list\n"
dropped: { tables: 1, images: 1 }
```

Confirmed: default black and Arial produce no marks at all, red survives, a link suppresses its own underline mark, `\v` becomes `hardBreak`, `sectionBreak` is skipped, and ordered versus bulleted is decided by `glyphType` against `glyphSymbol`.

`tsc --noEmit` and `next lint` clean. End-to-end picker flow confirmed manually in the browser against a real Google Doc.

## Deploying this

Three public variables are required, and the button hides itself via `isPickerConfigured()` until all three are present:

- `NEXT_PUBLIC_GOOGLE_CLIENT_ID` — same value as `GOOGLE_ID`
- `NEXT_PUBLIC_GOOGLE_PICKER_KEY` — browser API key, restricted to the Google Picker API and to the app's origins
- `NEXT_PUBLIC_GOOGLE_PROJECT_NUMBER` — Cloud project number, for the Picker's `setAppId`

Google Docs API and Google Picker API must be enabled on the project, and the app's origins added to the existing OAuth client.

The picker key ships inside the client bundle, as every `NEXT_PUBLIC_` value does. That is fine for a Picker key, but only because it is referrer-restricted — an unrestricted key in a public bundle is usable by anyone reading the page source.

## Not covered

`package-lock.json` is not in this branch. It carried unrelated local churn, so `package.json` gains `@tiptap/extension-link` on its own and the lockfile needs regenerating before a clean `npm ci` will pass.
