### PR TITLE
fix: presigned blob uploads and explicit token

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,30 +1,39 @@
 import { NextResponse } from "next/server";
-import { handleUpload, type HandleUploadBody } from "@vercel/blob/client";
+import { issueSignedToken } from "@vercel/blob";
+import {
+  handleUploadPresigned,
+  type HandleUploadPresignedBody,
+} from "@vercel/blob/client";
 
 import getServerSession from "@/lib/customHooks/getServerSession";
 import { resolveDocumentAccess } from "@/lib/documentAccess";
 import { ALLOWED_CONTENT_TYPES, MAX_UPLOAD_BYTES } from "@/lib/images/constants";
 
 /**
- * Mints the short-lived token the browser uploads with.
+ * Issues the short-lived presigned URL the browser uploads with.
  *
  * Bytes go straight from the browser to Blob storage and never pass through
- * this route, which is what keeps large images clear of the request body limit
- * on a server action. That also means this handler is the only point where an
- * upload can be refused — the limits returned below travel with the token and
- * are enforced by Blob itself.
+ * this route, which keeps large images clear of the 4.5MB request body limit a
+ * serverless function has. That also makes this handler the only point where an
+ * upload can be refused — the constraints below are signed into the token and
+ * enforced by Blob itself rather than taken on trust.
+ *
+ * This is the presigned flow rather than `handleUpload`. Stores created since
+ * Vercel moved to presigned uploads reject the older client-token path outright,
+ * and because the rejection comes back without CORS headers the browser reports
+ * it as a CORS failure rather than as the 4xx it actually is.
  */
 export async function POST(request: Request) {
-  const body = (await request.json()) as HandleUploadBody;
+  const body = (await request.json()) as HandleUploadPresignedBody;
 
   try {
-    const result = await handleUpload({
+    const result = await handleUploadPresigned({
       body,
       request,
-      onBeforeGenerateToken: async (_pathname, clientPayload) => {
+      getSignedToken: async (pathname, clientPayload) => {
         // Checked explicitly because the failure is otherwise indistinguishable
-        // from a rejected upload: the client only ever reports "Failed to
-        // retrieve the client token", whatever went wrong here.
+        // from a rejected upload: whatever goes wrong here, the client reports
+        // only that it could not get a token.
         if (!process.env.BLOB_READ_WRITE_TOKEN)
           throw new Error("BLOB_READ_WRITE_TOKEN is not set");
 
@@ -38,12 +47,27 @@ export async function POST(request: Request) {
         const access = await resolveDocumentAccess(clientPayload, session.id);
         if (!access) throw new Error("No access to that document");
 
-        return {
+        const token = await issueSignedToken({
+          // Passed explicitly so the credential does not depend on the
+          // environment: left out, the SDK reaches for VERCEL_OIDC_TOKEN
+          // whenever BLOB_STORE_ID is set, which fails anywhere OIDC is not
+          // enabled — local development included.
+          token: process.env.BLOB_READ_WRITE_TOKEN,
+          pathname,
+          operations: ["put"],
           allowedContentTypes: ALLOWED_CONTENT_TYPES,
           maximumSizeInBytes: MAX_UPLOAD_BYTES,
-          // Without this, two people uploading screenshot.png collide on one
-          // pathname and the second upload is rejected.
-          addRandomSuffix: true,
+        });
+
+        return {
+          token,
+          urlOptions: {
+            allowedContentTypes: ALLOWED_CONTENT_TYPES,
+            maximumSizeInBytes: MAX_UPLOAD_BYTES,
+            // Without this, two people uploading screenshot.png collide on one
+            // pathname and the second upload is rejected.
+            addRandomSuffix: true,
+          },
         };
       },
     });
@@ -53,7 +77,7 @@ export async function POST(request: Request) {
     // Logged rather than only returned: the client library replaces whatever
     // this responds with by its own generic message, so an unlogged reason is
     // a reason nobody ever sees.
-    console.error("[upload] token request failed:", error);
+    console.error("[upload] presign request failed:", error);
 
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Upload failed" },

--- a/lib/googleDocs/rehostImages.ts
+++ b/lib/googleDocs/rehostImages.ts
@@ -63,6 +63,10 @@ export const rehostImages = async (doc: TiptapNode) => {
       if (!extension) throw new Error(`unsupported type ${blob.type}`);
 
       const { url } = await put(`imported-${index + 1}.${extension}`, blob, {
+        // Explicit for the same reason as the upload route: without it the SDK
+        // prefers VERCEL_OIDC_TOKEN whenever BLOB_STORE_ID is set, and OIDC is
+        // not enabled in every environment.
+        token: process.env.BLOB_READ_WRITE_TOKEN,
         access: "public",
         addRandomSuffix: true,
         contentType: blob.type,

--- a/lib/images/upload.ts
+++ b/lib/images/upload.ts
@@ -1,4 +1,4 @@
-import { upload } from "@vercel/blob/client";
+import { uploadPresigned } from "@vercel/blob/client";
 
 import { ALLOWED_CONTENT_TYPES, MAX_UPLOAD_BYTES } from "./constants";
 
@@ -69,7 +69,10 @@ export const resolveImageSrc = async (
   if (file.size > MAX_UPLOAD_BYTES)
     throw new Error("Images must be under 5MB");
 
-  const blob = await upload(file.name, file, {
+  // Presigned rather than the older client-token upload: this store rejects
+  // that path, and the rejection arrives without CORS headers so the browser
+  // reports it as a CORS error instead of the 4xx it is.
+  const blob = await uploadPresigned(file.name, file, {
     access: "public",
     handleUploadUrl: "/api/upload",
     clientPayload: docId,


### PR DESCRIPTION
Two fixes to the image upload path shipped in #70, both found by actually running it.

## Presigned uploads

The upload in #70 used `handleUpload` + `upload()` — the client-token flow. Every upload failed identically in local development and in production:

```
Access to fetch at 'https://vercel.com/api/blob/?pathname=image.png'
blocked by CORS policy: No 'Access-Control-Allow-Origin' header
```

That reads as a CORS problem and is not one. The request was rejected before any CORS header was attached, so the browser reported the absence of the header rather than the 4xx underneath it. The cause is the store: it was created after Vercel moved to presigned uploads, which is why it came with `BLOB_STORE_ID` and `BLOB_WEBHOOK_PUBLIC_KEY` and only offered `BLOB_READ_WRITE_TOKEN` behind an extra checkbox. Stores of that generation reject the older client-token path.

So the route moves to `handleUploadPresigned` + `getSignedToken`, and the browser to `uploadPresigned`. The two have to change together — they exchange a different request body.

None of the authorisation changes: session, then `resolveDocumentAccess` on the target document, then the content-type allowlist and size cap. Those constraints are now signed into the presigned URL instead of into a client token, and are still enforced by Blob rather than taken on trust.

## Credentials no longer depend on the environment

With that fixed, uploads then failed with:

```
Vercel Blob: OIDC is enabled for this project, but not for the "development" environment.
```

`issueSignedToken` reaches for `VERCEL_OIDC_TOKEN` whenever `BLOB_STORE_ID` is present, and OIDC is not enabled in every environment. Passing `token` explicitly takes priority over both that and the ambient `BLOB_READ_WRITE_TOKEN`, so the credential is the same everywhere and there is no configuration that works in production but not locally.

`rehostImages` had the same latent bug — it calls `put()` during a Google Docs import and would have thrown the identical error the first time anyone imported a document containing an image. Nobody had hit it yet because it only runs on that path.

## What this does not fix

Uploads now succeed. **Serving them does not.** The presigned flow returns a URL on `<store>.private.blob.vercel-storage.com`, and loading it gets a 403:

```
GET https://….private.blob.vercel-storage.com/image-….png 403 (Forbidden)
```

`presign()` never sends `access`, and `issueSignedToken` has no option for it, so in this SDK version the presigned client-upload path can only produce private blobs. A browser loading `<img src>` is unauthenticated, so this fails in production exactly as it does locally — it is a property of the object, not of the environment.

Worth noting the asymmetry: `rehostImages` calls `put({ access: "public" })` against this same store and that does produce working public URLs. Public blobs are fine here; it is specifically the presigned path that cannot create them.

Two ways forward, not decided yet:

- **Serve through a proxy route.** Keep these working uploads, add a route that streams the blob with the server token after checking `documentAccess`. Documents would store a stable first-party URL, and it closes the gap flagged in #70 — that a public blob URL is readable by anyone holding it, regardless of `linkAccess`. Cost is that every image view hits a function instead of a CDN.
- **Upload server-side instead.** Send the file to a route and call `put({ access: "public" })`, the same call `rehostImages` already makes. Simplest, CDN-served, but bytes pass through the function so Vercel's 4.5MB body limit applies and images stay publicly readable.

Merging this is still worth it on its own: without it uploads fail outright, and the import path throws on the first document containing an image.

`tsc --noEmit` and `next lint` clean.
