### PR TITLE
fix: serve private blob images, flag imported docs

### DIFF
--- a/app/api/image/[...path]/route.ts
+++ b/app/api/image/[...path]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { issueSignedToken, presignUrl } from "@vercel/blob";
+
+import getServerSession from "@/lib/customHooks/getServerSession";
+import { resolveDocumentAccess } from "@/lib/documentAccess";
+import { documentIdFromBlobPath } from "@/lib/images/paths";
+
+// Long enough for a slow page to finish loading its images, short enough that a
+// copied URL is worthless by the time it is pasted anywhere.
+const LINK_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Serves an uploaded image to whoever is allowed to read the document it
+ * belongs to.
+ *
+ * The Blob store is private, so its URLs answer 403 to an unauthenticated
+ * request — and a browser loading an <img> is always unauthenticated. Rather
+ * than work around that, this leans on it: the image is exactly as private as
+ * the document, which a public blob URL could never be, since anyone holding
+ * one could read it however `linkAccess` was set.
+ *
+ * The bytes are not streamed through here. This redirects to a short-lived
+ * presigned URL, so the browser fetches from Blob directly and the function
+ * only decides whether it may.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: { path: string[] } },
+) {
+  const documentId = documentIdFromBlobPath(params.path);
+  if (!documentId) return new NextResponse(null, { status: 404 });
+
+  const session = await getServerSession();
+  const access = await resolveDocumentAccess(documentId, session?.id ?? "");
+  if (!access) return new NextResponse(null, { status: 403 });
+
+  const pathname = params.path.join("/");
+
+  try {
+    const signedToken = await issueSignedToken({
+      // Explicit for the same reason as the upload route: left out, the SDK
+      // prefers VERCEL_OIDC_TOKEN whenever BLOB_STORE_ID is set, which fails
+      // anywhere OIDC is not enabled.
+      token: process.env.BLOB_READ_WRITE_TOKEN,
+      pathname,
+      operations: ["get"],
+      validUntil: Date.now() + LINK_TTL_MS,
+    });
+
+    const { presignedUrl } = await presignUrl(signedToken, {
+      operation: "get",
+      pathname,
+      access: "private",
+    });
+
+    return NextResponse.redirect(presignedUrl, {
+      status: 307,
+      // The destination expires, so a cached redirect would outlive what it
+      // points at. Blob sets its own caching on the image behind it.
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  } catch (error) {
+    console.error("[image] could not sign a read for", pathname, error);
+    return new NextResponse(null, { status: 500 });
+  }
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -8,6 +8,7 @@ import {
 import getServerSession from "@/lib/customHooks/getServerSession";
 import { resolveDocumentAccess } from "@/lib/documentAccess";
 import { ALLOWED_CONTENT_TYPES, MAX_UPLOAD_BYTES } from "@/lib/images/constants";
+import { isBlobPathFor } from "@/lib/images/paths";
 
 /**
  * Issues the short-lived presigned URL the browser uploads with.
@@ -46,6 +47,14 @@ export async function POST(request: Request) {
         // as opening one: a collaborator, or link access being on.
         const access = await resolveDocumentAccess(clientPayload, session.id);
         if (!access) throw new Error("No access to that document");
+
+        // The path is what the image route later reads the document id back
+        // out of, so a token is only ever signed for a path that agrees with
+        // the document just checked — otherwise anyone could write into
+        // another document's folder and have it served to that document's
+        // readers.
+        if (!isBlobPathFor(pathname, clientPayload))
+          throw new Error("Upload path does not belong to that document");
 
         const token = await issueSignedToken({
           // Passed explicitly so the credential does not depend on the

--- a/app/document/actions.ts
+++ b/app/document/actions.ts
@@ -27,6 +27,7 @@ export const GetAllDocs = async () => {
         name: true,
         data: true,
         updatedAt: true,
+        source: true,
         createdBy: { select: { id: true, name: true, picture: true } },
         users: {
           select: {

--- a/app/document/components/DocCardItem.tsx
+++ b/app/document/components/DocCardItem.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import type { User } from "@prisma/client";
+import { Import } from "lucide-react";
+import type { DocumentSource, User } from "@prisma/client";
 
 import prettifyDate from "@/helpers/prettifyDates";
 import useClientSession from "@/lib/customHooks/useClientSession";
@@ -27,17 +28,29 @@ type DocCardItemProps = {
   data: string | null;
   title: string;
   updatedAt: Date;
+  source?: DocumentSource;
   createdBy: { id: string; name: string; picture: string | null };
   users: { user: Pick<User, "name" | "picture"> }[];
   view: "grid" | "list";
   colorIndex: number;
 };
 
+// Imported content was written in another editor, so a stray margin or an odd
+// font is likely something the conversion did rather than something the writer
+// chose. Saying where a document came from is what makes that legible.
+const ImportedBadge = () => (
+  <span className="inline-flex items-center gap-1 h-[18px] px-1.5 rounded font-mono uppercase tracking-wider text-[9px] shrink-0 border border-[var(--lp-border)] bg-[color-mix(in_oklab,var(--lp-accent)_10%,var(--lp-card))] text-[var(--lp-muted)]">
+    <Import className="w-2.5 h-2.5" strokeWidth={2} />
+    Imported
+  </span>
+);
+
 export default function DocCardItem({
   docId,
   data,
   title,
   updatedAt,
+  source,
   createdBy,
   users,
   view,
@@ -76,6 +89,7 @@ export default function DocCardItem({
     };
   }, [debounce]);
 
+  const isImported = source === "GOOGLE_DOCS";
   const isOwner = !session?.id || createdBy.id === session.id;
   const ownerName = isOwner ? "You" : createdBy.name;
   const ownerInitial = (ownerName[0] ?? "?").toUpperCase();
@@ -109,6 +123,7 @@ export default function DocCardItem({
               onChange={e => { setName(e.target.value); debounce(e.target.value); }}
             />
           </div>
+          {isImported && <ImportedBadge />}
         </div>
 
         {/* Owner */}
@@ -144,13 +159,16 @@ export default function DocCardItem({
 
       {/* Card footer */}
       <div className="p-3">
-        <input
-          ref={inputRef}
-          value={name}
-          className="text-[13px] font-medium truncate w-full bg-transparent border-none outline-none focus:bg-[var(--lp-paper-2)] focus:px-1 rounded transition text-[var(--lp-ink)]"
-          onClick={e => e.stopPropagation()}
-          onChange={e => { setName(e.target.value); debounce(e.target.value); }}
-        />
+        <div className="flex items-center gap-1.5">
+          <input
+            ref={inputRef}
+            value={name}
+            className="text-[13px] font-medium truncate flex-1 min-w-0 bg-transparent border-none outline-none focus:bg-[var(--lp-paper-2)] focus:px-1 rounded transition text-[var(--lp-ink)]"
+            onClick={e => e.stopPropagation()}
+            onChange={e => { setName(e.target.value); debounce(e.target.value); }}
+          />
+          {isImported && <ImportedBadge />}
+        </div>
         <div className="flex items-center justify-between mt-1.5">
           <div className="flex items-center gap-1.5">
             <AvatarList users={users} />

--- a/app/document/components/DocumentContent.tsx
+++ b/app/document/components/DocumentContent.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { LayoutGrid, List } from "lucide-react";
+import type { DocumentSource } from "@prisma/client";
 
 import { CreateNewDocument } from "./Header/actions";
 import { createGuestDocument } from "@/lib/guestServices";
@@ -18,6 +19,8 @@ type Doc = {
   name: string;
   data: string | null;
   updatedAt: Date;
+  // Absent on guest documents, which are only ever created locally.
+  source?: DocumentSource;
   createdBy: { id: string; name: string; picture: string | null };
   users: { user: { name: string; picture: string | null } }[];
 };
@@ -90,6 +93,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
     .filter(d => {
       if (folder === "Drafts") return isGuest || d.createdBy.id === userId;
       if (folder === "Shared") return !isGuest && d.createdBy.id !== userId;
+      if (folder === "Imported") return d.source === "GOOGLE_DOCS";
       return true;
     })
     .filter(d => !q || d.name.toLowerCase().includes(q.toLowerCase()))
@@ -157,6 +161,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                       data={d.data}
                       title={d.name}
                       updatedAt={d.updatedAt}
+                      source={d.source}
                       createdBy={d.createdBy}
                       users={d.users}
                       view="grid"
@@ -252,6 +257,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                       data={d.data}
                       title={d.name}
                       updatedAt={d.updatedAt}
+                      source={d.source}
                       createdBy={d.createdBy}
                       users={d.users}
                       view="grid"
@@ -271,6 +277,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                       data={d.data}
                       title={d.name}
                       updatedAt={d.updatedAt}
+                      source={d.source}
                       createdBy={d.createdBy}
                       users={d.users}
                       view="list"

--- a/app/document/components/Header/actions.ts
+++ b/app/document/components/Header/actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import type { DocumentSource } from "@prisma/client";
+
 import prisma from "@/prisma/prismaClient";
 import getServerSession from "@/lib/customHooks/getServerSession";
 
@@ -45,9 +47,18 @@ export const SearchDocAction = async (value: string) => {
   }
 };
 
+// `id` lets a caller decide the document's id before it exists, which an import
+// needs: its images are stored under that id, and they are copied out of Google
+// before anything is written, so the id has to be known first.
+type CreateDocumentOptions = {
+  id?: string;
+  source?: DocumentSource;
+};
+
 export const CreateNewDocument = async (
   initialData?: string,
   name?: string,
+  options?: CreateDocumentOptions,
 ) => {
   try {
     const session = await getServerSession();
@@ -62,6 +73,8 @@ export const CreateNewDocument = async (
         data: initialData ?? "",
         // Left unset when absent so the schema default applies.
         ...(name?.trim() ? { name: name.trim() } : {}),
+        ...(options?.id ? { id: options.id } : {}),
+        ...(options?.source ? { source: options.source } : {}),
         userId: session.id,
         users: {
           create: {

--- a/app/document/components/Sidebar.tsx
+++ b/app/document/components/Sidebar.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { Layers2, PenLine, Users } from "lucide-react";
+import { Import, Layers2, PenLine, Users } from "lucide-react";
 
 import AppSidebar from "@/components/AppSidebar";
 
 const FOLDERS = [
-  { id: "all",    label: "All documents",  Icon: Layers2 },
-  { id: "Drafts", label: "Drafts",          Icon: PenLine },
-  { id: "Shared", label: "Shared with me",  Icon: Users   },
+  { id: "all",      label: "All documents",   Icon: Layers2 },
+  { id: "Drafts",   label: "Drafts",          Icon: PenLine },
+  { id: "Shared",   label: "Shared with me",  Icon: Users   },
+  { id: "Imported", label: "Imported",        Icon: Import  },
 ];
 
 type SidebarProps = {

--- a/app/document/import/actions.ts
+++ b/app/document/import/actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { randomUUID } from "node:crypto";
+
 import { CreateNewDocument } from "../components/Header/actions";
 import { CreateDocVersion } from "@/app/writer/[id]/versions/actions";
 import { rehostImages } from "@/lib/googleDocs/rehostImages";
@@ -25,10 +27,19 @@ export const ImportDocument = async (name: string, data: string) => {
     return { success: false as const, error: "That document could not be read" };
   }
 
-  const rehosted = await rehostImages(doc);
+  // Decided here rather than by the database because images are stored under
+  // it and they are copied before the document row exists. An import that then
+  // fails to save leaves those images behind, which costs a little storage —
+  // preferable to writing a document whose pictures expire within the hour.
+  const documentId = randomUUID();
+
+  const rehosted = await rehostImages(doc, documentId);
   const stored = JSON.stringify(rehosted.doc);
 
-  const created = await CreateNewDocument(stored, name);
+  const created = await CreateNewDocument(stored, name, {
+    id: documentId,
+    source: "GOOGLE_DOCS",
+  });
   if (!created.success || !created.data)
     return { ...created, failedImages: rehosted.failed };
 

--- a/lib/googleDocs/rehostImages.ts
+++ b/lib/googleDocs/rehostImages.ts
@@ -1,5 +1,6 @@
 import { put } from "@vercel/blob";
 
+import { blobPathname, imageSrc } from "@/lib/images/paths";
 import type { TiptapNode } from "./toTiptap";
 
 // Enough at once to keep an image-heavy import inside a function timeout,
@@ -43,8 +44,13 @@ const pruneEmptyImages = (node: TiptapNode): TiptapNode => {
  * never reaches the server, so there is no authenticated fetch to forward. The
  * URLs are pre-signed and need no credentials, and an image that turns out to
  * need them simply fails and is reported.
+ *
+ * `docId` is the id the imported document is about to be created with. Images
+ * are stored under it and served through the image route, exactly as an image
+ * uploaded in the editor is, so nothing downstream has to know where a picture
+ * came from.
  */
-export const rehostImages = async (doc: TiptapNode) => {
+export const rehostImages = async (doc: TiptapNode, docId: string) => {
   const images = collectImages(doc);
   if (images.length === 0) return { doc, failed: 0 };
 
@@ -62,17 +68,21 @@ export const rehostImages = async (doc: TiptapNode) => {
       const extension = EXTENSIONS[blob.type];
       if (!extension) throw new Error(`unsupported type ${blob.type}`);
 
-      const { url } = await put(`imported-${index + 1}.${extension}`, blob, {
-        // Explicit for the same reason as the upload route: without it the SDK
-        // prefers VERCEL_OIDC_TOKEN whenever BLOB_STORE_ID is set, and OIDC is
-        // not enabled in every environment.
-        token: process.env.BLOB_READ_WRITE_TOKEN,
-        access: "public",
-        addRandomSuffix: true,
-        contentType: blob.type,
-      });
+      const stored = await put(
+        blobPathname(docId, `imported-${index + 1}.${extension}`),
+        blob,
+        {
+          // Explicit for the same reason as the upload route: without it the
+          // SDK prefers VERCEL_OIDC_TOKEN whenever BLOB_STORE_ID is set, and
+          // OIDC is not enabled in every environment.
+          token: process.env.BLOB_READ_WRITE_TOKEN,
+          access: "private",
+          addRandomSuffix: true,
+          contentType: blob.type,
+        },
+      );
 
-      node.attrs = { ...node.attrs, src: url };
+      node.attrs = { ...node.attrs, src: imageSrc(stored.pathname) };
     } catch {
       failed += 1;
       node.attrs = { ...node.attrs, src: "" };

--- a/lib/guestServices.ts
+++ b/lib/guestServices.ts
@@ -43,7 +43,10 @@ export const createGuestDocument = (initialData?: string) => {
     indexedHash: null,
     thumbnail: null,
     deleteUrl: null,
-    linkAccess: "NONE"
+    linkAccess: "NONE",
+    // Importing from Google Docs needs a session, so a guest document is
+    // always one someone started here.
+    source: "BLANK"
   }
 
   const allDocuments: Document[] = JSON.parse(localStorage.getItem('documents') || '[]');

--- a/lib/hooks/useDocs.ts
+++ b/lib/hooks/useDocs.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import useSWR, { mutate } from "swr";
+import type { DocumentSource } from "@prisma/client";
 
 import { GetAllDocs } from "@/app/document/actions";
 import { getAllGuestDocuments } from "@/lib/guestServices";
@@ -10,6 +11,8 @@ type Doc = {
   name: string;
   data: string | null;
   updatedAt: Date;
+  // Absent on guest documents, which are only ever created locally.
+  source?: DocumentSource;
   createdBy: { id: string; name: string; picture: string | null };
   users: { user: { name: string; picture: string | null } }[];
 };

--- a/lib/images/paths.ts
+++ b/lib/images/paths.ts
@@ -1,0 +1,37 @@
+// Where an uploaded image lives in Blob storage, and how a document refers to
+// it. Shared by the browser (which uploads), the presign route (which authorises
+// the upload) and the image route (which authorises the read), so all three
+// agree on one scheme.
+
+const ROOT = "documents";
+
+// The document id is part of the blob path because that is the only thing the
+// browser hands back when it loads the image — an <img> has no room for a
+// second parameter. Deriving it from the path keeps one source of truth.
+export const blobPathname = (docId: string, fileName: string) =>
+  `${ROOT}/${docId}/${sanitizeFileName(fileName)}`;
+
+export const documentIdFromBlobPath = (segments: string[]) =>
+  segments.length > 2 && segments[0] === ROOT ? segments[1] : null;
+
+export const isBlobPathFor = (pathname: string, docId: string) =>
+  pathname.startsWith(`${ROOT}/${docId}/`);
+
+// Blob itself only rejects "//", but a name reaches this document as a URL, so
+// anything with meaning in one — a query, a fragment, a path separator — has to
+// go before it is stored rather than after it has already broken a link.
+export function sanitizeFileName(fileName: string) {
+  const cleaned = fileName.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+/, "");
+  return cleaned.slice(-100) || "image";
+}
+
+/**
+ * The `src` a document stores for an uploaded image.
+ *
+ * Blobs in this store are private, so the storage URL answers 403 to the
+ * browser. Documents point at this route instead, which checks who is asking
+ * before handing the image over — the same rule that governs opening the
+ * document the image lives in.
+ */
+export const imageSrc = (pathname: string) =>
+  `/api/image/${pathname.split("/").map(encodeURIComponent).join("/")}`;

--- a/lib/images/upload.ts
+++ b/lib/images/upload.ts
@@ -1,6 +1,7 @@
 import { uploadPresigned } from "@vercel/blob/client";
 
 import { ALLOWED_CONTENT_TYPES, MAX_UPLOAD_BYTES } from "./constants";
+import { blobPathname, imageSrc } from "./paths";
 
 export const isSupportedImage = (file: File) =>
   ALLOWED_CONTENT_TYPES.includes(file.type);
@@ -72,11 +73,15 @@ export const resolveImageSrc = async (
   // Presigned rather than the older client-token upload: this store rejects
   // that path, and the rejection arrives without CORS headers so the browser
   // reports it as a CORS error instead of the 4xx it is.
-  const blob = await uploadPresigned(file.name, file, {
-    access: "public",
+  //
+  // The store is private — it refuses a public write outright — so the returned
+  // storage URL is not something an <img> can load. The document points at the
+  // image route instead, which serves it to readers of this document.
+  const blob = await uploadPresigned(blobPathname(docId, file.name), file, {
+    access: "private",
     handleUploadUrl: "/api/upload",
     clientPayload: docId,
   });
 
-  return blob.url;
+  return imageSrc(blob.pathname);
 };

--- a/prisma/migrations/20260819120000_document_source/migration.sql
+++ b/prisma/migrations/20260819120000_document_source/migration.sql
@@ -1,0 +1,6 @@
+CREATE TYPE "DocumentSource" AS ENUM ('BLANK', 'GOOGLE_DOCS');
+
+-- Existing rows keep the default. Imports before this column are not
+-- recoverable after the fact: nothing was recorded at the time that
+-- distinguishes them from a document someone typed.
+ALTER TABLE "Document" ADD COLUMN "source" "DocumentSource" NOT NULL DEFAULT 'BLANK';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,14 @@ enum LinkAccess {
   EDIT
 }
 
+// Where a document's first version came from. Imported documents are worth
+// telling apart: their content was written somewhere else, so a formatting
+// oddity is likely an import artefact rather than something someone typed.
+enum DocumentSource {
+  BLANK
+  GOOGLE_DOCS
+}
+
 model Document {
   id        String   @id @default(uuid())
   name      String   @default("Untitled Document")
@@ -50,7 +58,8 @@ model Document {
   thumbnail String?
   deleteUrl String?
 
-  linkAccess LinkAccess @default(NONE)
+  linkAccess LinkAccess     @default(NONE)
+  source     DocumentSource @default(BLANK)
 
   // Hash of `data` as of the last fully successful index. A mismatch against
   // the current data means the chunks are stale — indexing failed, or the


### PR DESCRIPTION
Uploads started working in #71, but the uploaded image could not be viewed:

```
GET https://….private.blob.vercel-storage.com/image-….png 403 (Forbidden)
```

## Why

The store is private, and not by accident of the code. Probed directly against it:

```
public:  FAILED — Vercel Blob: Cannot use public access on a private store.
                  The store is configured with private access.
private: host=….private.blob.vercel-storage.com   anonymous GET = 403
```

So `access: "public"` was never going to work here — not on the presigned client upload, and not on the server-side `put()` in the import path either, which would have thrown the moment anyone imported a document containing an image. A browser loading an `<img>` is unauthenticated, which is exactly what a private blob refuses.

## What this does instead

Rather than work around the store being private, this leans on it. Documents no longer store a storage URL; they store `/api/image/<pathname>`, a first-party route that decides whether the caller may read the image and then redirects to a short-lived presigned URL.

- The document id is part of the blob path (`documents/<docId>/<file>`), because an `<img>` sends nothing back but its own URL. The route reads the id out of the path and runs `resolveDocumentAccess` — the same rule that governs opening the document.
- The presign route now refuses to sign a path that does not belong to the document it just authorised, so nobody can write into another document's folder and have it served to that document's readers.
- Bytes are not streamed through the function. It signs a 5-minute URL and redirects, so the browser still fetches from Blob directly. The redirect is `no-store`, since a cached one would outlive what it points at.
- Imported images take the same path, so nothing downstream has to know whether a picture was uploaded or imported.

This also closes something flagged in #70: a public blob URL is readable by anyone holding it however `linkAccess` is set. An image is now exactly as private as the document it sits in.

Guest images are untouched — no session means no upload token, so they stay data URIs in localStorage.

## Imported documents are flagged

`Document.source` (`BLANK` | `GOOGLE_DOCS`), which the import path had to know about anyway: images are stored under the document id, and they are copied out of Google before the row exists, so the id is generated up front and passed to `CreateNewDocument`.

In the dashboard, imported documents carry an "Imported" badge in both grid and list view, and there is an "Imported" folder in the sidebar. It is worth telling apart: that content was written in another editor, so a stray margin or an odd font is likely something the conversion did rather than something the writer chose.

Existing rows default to `BLANK`. Imports from before this column are not recoverable after the fact — nothing was recorded at the time that distinguishes them.

## Before merging

`prisma/migrations/20260819120000_document_source` has **not** been applied. `DATABASE_URL` points at the Neon instance behind production, so that is deliberately left to a deploy rather than run from a branch.

Images uploaded before this change keep pointing at private storage URLs and stay broken; they need re-uploading.

Markdown export now emits the relative `/api/image/…` path, which resolves inside the app but not in an exported file opened elsewhere. Untouched here.

`tsc --noEmit` and `next lint` clean. The presign-then-read chain was verified against the real store: private write, then presigned `GET` returning `200 image/png`.
