### PR TITLE
perf: stop fetching whole documents to draw thumbnails

### DIFF
--- a/app/api/image/[...path]/route.ts
+++ b/app/api/image/[...path]/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
-import { issueSignedToken, presignUrl } from "@vercel/blob";
 
 import getServerSession from "@/lib/customHooks/getServerSession";
 import { resolveDocumentAccess } from "@/lib/documentAccess";
 import { documentIdFromBlobPath } from "@/lib/images/paths";
+import { IMAGE_LINK_TTL_MS, signedImageUrl } from "@/lib/images/signedRead";
 
-// Long enough for a slow page to finish loading its images, short enough that a
-// copied URL is worthless by the time it is pasted anywhere.
-const LINK_TTL_MS = 5 * 60 * 1000;
+// Kept under the life of the URL it points at, so a cached redirect can never
+// hand out one that has already expired. The cost is that access revoked in
+// this window is not felt until it lapses.
+const REDIRECT_CACHE_SECONDS = Math.floor(IMAGE_LINK_TTL_MS / 1000) - 60;
 
 /**
  * Serves an uploaded image to whoever is allowed to read the document it
@@ -37,27 +38,11 @@ export async function GET(
   const pathname = params.path.join("/");
 
   try {
-    const signedToken = await issueSignedToken({
-      // Explicit for the same reason as the upload route: left out, the SDK
-      // prefers VERCEL_OIDC_TOKEN whenever BLOB_STORE_ID is set, which fails
-      // anywhere OIDC is not enabled.
-      token: process.env.BLOB_READ_WRITE_TOKEN,
-      pathname,
-      operations: ["get"],
-      validUntil: Date.now() + LINK_TTL_MS,
-    });
-
-    const { presignedUrl } = await presignUrl(signedToken, {
-      operation: "get",
-      pathname,
-      access: "private",
-    });
-
-    return NextResponse.redirect(presignedUrl, {
+    return NextResponse.redirect(await signedImageUrl(pathname), {
       status: 307,
-      // The destination expires, so a cached redirect would outlive what it
-      // points at. Blob sets its own caching on the image behind it.
-      headers: { "Cache-Control": "private, no-store" },
+      headers: {
+        "Cache-Control": `private, max-age=${REDIRECT_CACHE_SECONDS}`,
+      },
     });
   } catch (error) {
     console.error("[image] could not sign a read for", pathname, error);

--- a/app/document/actions.ts
+++ b/app/document/actions.ts
@@ -25,7 +25,7 @@ export const GetAllDocs = async () => {
       select: {
         id: true,
         name: true,
-        data: true,
+        preview: true,
         updatedAt: true,
         source: true,
         createdBy: { select: { id: true, name: true, picture: true } },
@@ -33,6 +33,7 @@ export const GetAllDocs = async () => {
           select: {
             user: {
               select: {
+                id: true,
                 name: true,
                 picture: true,
               },

--- a/app/document/components/Card/actions.ts
+++ b/app/document/components/Card/actions.ts
@@ -5,6 +5,48 @@ import { revalidatePath } from "next/cache";
 import getServerSession from "@/lib/customHooks/getServerSession";
 import prisma from "@/prisma/prismaClient";
 
+/**
+ * Copies a document the caller can already open.
+ *
+ * The body is read and written entirely here. Duplicating used to send the
+ * source document down to the browser with the dashboard listing and post it
+ * back, which meant every listing carried every document's full text just in
+ * case someone pressed duplicate.
+ */
+export const DuplicateDocument = async (docId: string) => {
+  try {
+    const session = await getServerSession();
+    if (!session.id)
+      return { success: false, error: "User is not logged in" };
+
+    const source = await prisma.document.findFirst({
+      where: {
+        id: docId,
+        users: { some: { userId: session.id } },
+      },
+      select: { name: true, data: true, preview: true, source: true },
+    });
+    if (!source) return { success: false, error: "Document does not exist" };
+
+    const copy = await prisma.document.create({
+      data: {
+        name: `${source.name} (copy)`,
+        data: source.data,
+        preview: source.preview,
+        source: source.source,
+        userId: session.id,
+        users: { create: { user: { connect: { id: session.id } } } },
+      },
+    });
+    revalidatePath("/");
+
+    return { success: true, data: copy };
+  } catch (e) {
+    console.error(e);
+    return { success: false, error: "Internal server error" };
+  }
+};
+
 export const DeleteDocument = async (docId: any) => {
   try {
     const session = await getServerSession();

--- a/app/document/components/Card/components/Options.tsx
+++ b/app/document/components/Card/components/Options.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import {
   createGuestDocument,
   deleteGuestDocument,
+  getGuestDocumentDetails,
   updateGuestDocument,
 } from "@/lib/guestServices";
 import LoaderButton from "@/components/LoaderButton";
@@ -35,18 +36,15 @@ import { invalidateDocs } from "@/lib/hooks/useDocs";
 
 import { GetSharing } from "@/app/writer/[id]/sharing/actions";
 
-import { DeleteDocument, RenameDocument } from "../actions";
-import { CreateNewDocument } from "../../Header/actions";
+import { DeleteDocument, DuplicateDocument, RenameDocument } from "../actions";
 
 type CardOptionsPropType = {
   docId: string;
-  data?: string | null;
   inputRef: React.RefObject<HTMLInputElement>;
 };
 
 export default function CardOptions({
   docId,
-  data,
   inputRef,
 }: CardOptionsPropType) {
   const router = useRouter();
@@ -135,15 +133,16 @@ export default function CardOptions({
 
     try {
       if (session?.id) {
-        const response = await CreateNewDocument(data ?? "");
-        if (!response.success || !response.data) {
+        const response = await DuplicateDocument(docId);
+        if (!response.success) {
           toast.error(response.error);
           return;
         }
-        await RenameDocument(response.data.id, `${currentName} (copy)`);
         await invalidateDocs(session.id);
       } else {
-        const newDoc = createGuestDocument(data ?? "");
+        const newDoc = createGuestDocument(
+          getGuestDocumentDetails(docId)?.data ?? "",
+        );
         updateGuestDocument(newDoc.id, "name", `${currentName} (copy)`);
         await invalidateDocs();
       }

--- a/app/document/components/DocCardItem.tsx
+++ b/app/document/components/DocCardItem.tsx
@@ -25,12 +25,12 @@ const DOC_COLORS = [
 
 type DocCardItemProps = {
   docId: string;
-  data: string | null;
+  preview: string | null;
   title: string;
   updatedAt: Date;
   source?: DocumentSource;
   createdBy: { id: string; name: string; picture: string | null };
-  users: { user: Pick<User, "name" | "picture"> }[];
+  users: { user: Pick<User, "id" | "name" | "picture"> }[];
   view: "grid" | "list";
   colorIndex: number;
 };
@@ -47,7 +47,7 @@ const ImportedBadge = () => (
 
 export default function DocCardItem({
   docId,
-  data,
+  preview,
   title,
   updatedAt,
   source,
@@ -138,7 +138,7 @@ export default function DocCardItem({
         <div className="font-mono text-[10.5px] text-[var(--lp-muted)]">{formattedDate}</div>
 
         <span onClick={e => e.stopPropagation()}>
-          <CardOptions docId={docId} data={data} inputRef={inputRef} />
+          <CardOptions docId={docId} inputRef={inputRef} />
         </span>
       </div>
     );
@@ -151,7 +151,7 @@ export default function DocCardItem({
     >
       {/* Thumbnail area */}
       <DocThumbnail
-        data={data}
+        data={preview}
         accentColor={color}
         className="border-b border-[var(--lp-border)]"
         style={{ aspectRatio: "4/3.2" }}
@@ -176,7 +176,7 @@ export default function DocCardItem({
           </div>
           <div className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
             <span className="font-mono text-[10px] text-[var(--lp-muted)]">{formattedDate}</span>
-            <CardOptions docId={docId} data={data} inputRef={inputRef} />
+            <CardOptions docId={docId} inputRef={inputRef} />
           </div>
         </div>
       </div>

--- a/app/document/components/DocumentContent.tsx
+++ b/app/document/components/DocumentContent.tsx
@@ -4,26 +4,15 @@ import { useState, useEffect, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { LayoutGrid, List } from "lucide-react";
-import type { DocumentSource } from "@prisma/client";
 
 import { CreateNewDocument } from "./Header/actions";
 import { createGuestDocument } from "@/lib/guestServices";
 import useClientSession from "@/lib/customHooks/useClientSession";
 import { useDocs } from "@/lib/hooks/useDocs";
+import type { DocSummary as Doc } from "@/lib/types/document";
 import Sidebar from "./Sidebar";
 import DocTopBar from "./DocTopBar";
 import DocCardItem from "./DocCardItem";
-
-type Doc = {
-  id: string;
-  name: string;
-  data: string | null;
-  updatedAt: Date;
-  // Absent on guest documents, which are only ever created locally.
-  source?: DocumentSource;
-  createdBy: { id: string; name: string; picture: string | null };
-  users: { user: { name: string; picture: string | null } }[];
-};
 
 type Session = {
   id: string | null | undefined;
@@ -158,7 +147,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                     <DocCardItem
                       key={d.id}
                       docId={d.id}
-                      data={d.data}
+                      preview={d.preview}
                       title={d.name}
                       updatedAt={d.updatedAt}
                       source={d.source}
@@ -254,7 +243,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                     <DocCardItem
                       key={d.id}
                       docId={d.id}
-                      data={d.data}
+                      preview={d.preview}
                       title={d.name}
                       updatedAt={d.updatedAt}
                       source={d.source}
@@ -274,7 +263,7 @@ export default function DocumentContent({ initialDocs, initialSession, quickStar
                     <DocCardItem
                       key={d.id}
                       docId={d.id}
-                      data={d.data}
+                      preview={d.preview}
                       title={d.name}
                       updatedAt={d.updatedAt}
                       source={d.source}

--- a/app/document/components/Header/actions.ts
+++ b/app/document/components/Header/actions.ts
@@ -4,6 +4,7 @@ import type { DocumentSource } from "@prisma/client";
 
 import prisma from "@/prisma/prismaClient";
 import getServerSession from "@/lib/customHooks/getServerSession";
+import { previewOf } from "@/lib/documents/preview";
 
 export const SearchDocAction = async (value: string) => {
   const session = await getServerSession();
@@ -71,6 +72,7 @@ export const CreateNewDocument = async (
     const doc = await prisma.document.create({
       data: {
         data: initialData ?? "",
+        preview: previewOf(initialData),
         // Left unset when absent so the schema default applies.
         ...(name?.trim() ? { name: name.trim() } : {}),
         ...(options?.id ? { id: options.id } : {}),

--- a/app/document/page.tsx
+++ b/app/document/page.tsx
@@ -1,5 +1,6 @@
 import prisma from "@/prisma/prismaClient";
 import getServerSession from "@/lib/customHooks/getServerSession";
+import type { DocSummary } from "@/lib/types/document";
 import AskBar from "@/components/AskBar/AskBar";
 import DocumentContent from "./components/DocumentContent";
 import QuickStart from "./components/QuickStart";
@@ -7,14 +8,7 @@ import QuickStart from "./components/QuickStart";
 export default async function DocumentPage() {
   const session = await getServerSession();
 
-  let initialDocs: {
-    id: string;
-    name: string;
-    data: string | null;
-    updatedAt: Date;
-    createdBy: { id: string; name: string; picture: string | null };
-    users: { user: { name: string; picture: string | null } }[];
-  }[] = [];
+  let initialDocs: DocSummary[] = [];
 
   if (session?.id) {
     initialDocs = await prisma.document.findMany({
@@ -26,13 +20,14 @@ export default async function DocumentPage() {
       select: {
         id: true,
         name: true,
-        data: true,
+        preview: true,
         updatedAt: true,
+        source: true,
         createdBy: { select: { id: true, name: true, picture: true } },
         users: {
           select: {
             user: {
-              select: { name: true, picture: true },
+              select: { id: true, name: true, picture: true },
             },
           },
         },

--- a/app/writer/[id]/actions.ts
+++ b/app/writer/[id]/actions.ts
@@ -5,6 +5,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import prisma from "@/prisma/prismaClient";
 import getServerSession from "@/lib/customHooks/getServerSession";
 import { joinViaLink, resolveDocumentAccess } from "@/lib/documentAccess";
+import { previewOf } from "@/lib/documents/preview";
 import {
   generateTextOptions,
   prompts,
@@ -48,6 +49,9 @@ export const UpdateDocData = async (id: any, data: string) => {
     };
 
   try {
+    // Only the existence check is wanted here. Selecting the whole row pulled
+    // the document's body back out of the database on every autosave, which on
+    // a long document is the largest thing a keystroke can cost.
     const doc = await prisma.document.findFirst({
       where: {
         id,
@@ -55,6 +59,7 @@ export const UpdateDocData = async (id: any, data: string) => {
           some: { userId: session.id },
         },
       },
+      select: { id: true },
     });
     if (!doc)
       return {
@@ -71,6 +76,7 @@ export const UpdateDocData = async (id: any, data: string) => {
       },
       data: {
         data: data,
+        preview: previewOf(data),
         updatedAt: new Date(),
       },
     });

--- a/app/writer/[id]/editor/editorConfig.ts
+++ b/app/writer/[id]/editor/editorConfig.ts
@@ -7,6 +7,25 @@ import { Color, FontFamily, TextStyle } from "@tiptap/extension-text-style";
 
 import { cn } from "@/lib/utils";
 
+// The editor always shows the full image; the small copy exists only so a
+// dashboard thumbnail does not have to download it. `rendered: false` keeps it
+// out of the HTML while leaving it in the document JSON, which is what the
+// preview is built from.
+//
+// Width and height do reach the HTML, where they reserve the right amount of
+// space before the image loads. They are also what lets a preview draw the
+// picture at the size it has in the document rather than an arbitrary one.
+const ImageWithThumbnail = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      thumbData: { default: null, rendered: false },
+      width: { default: null },
+      height: { default: null },
+    };
+  },
+});
+
 export const extensions = [
   StarterKit.configure({
     // Undo/redo is Yjs's job once Collaboration is attached; the local history
@@ -37,7 +56,7 @@ export const extensions = [
   // `allowBase64` is what lets a guest's image survive: with no session there
   // is no upload token, so their images are data URIs, and the extension
   // strips those on parse otherwise.
-  Image.configure({ inline: true, allowBase64: true }),
+  ImageWithThumbnail.configure({ inline: true, allowBase64: true }),
 ];
 
 export const props = {

--- a/app/writer/[id]/editor/imageUpload.ts
+++ b/app/writer/[id]/editor/imageUpload.ts
@@ -2,10 +2,10 @@ import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey, type EditorState } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
-import { isSupportedImage } from "@/lib/images/upload";
+import { isSupportedImage, type UploadedImage } from "@/lib/images/upload";
 
 export type ImageUploadOptions = {
-  upload: (file: File) => Promise<string>;
+  upload: (file: File) => Promise<UploadedImage>;
   onError: (message: string) => void;
 };
 
@@ -148,7 +148,7 @@ export const ImageUpload = Extension.create<ImageUploadOptions>({
             );
 
             upload(file)
-              .then((src) => {
+              .then(({ src, thumbData, width, height }) => {
                 const pos = placeholderPos(view.state, id);
                 if (pos === null) return;
 
@@ -156,7 +156,7 @@ export const ImageUpload = Extension.create<ImageUploadOptions>({
                   .chain()
                   .insertContentAt(pos, {
                     type: "image",
-                    attrs: { src, alt: file.name },
+                    attrs: { src, thumbData, width, height, alt: file.name },
                   })
                   .run();
               })

--- a/components/AvatarList.tsx
+++ b/components/AvatarList.tsx
@@ -6,7 +6,7 @@ import getInitials from "@/helpers/getInitials";
 
 type AvatarListPropType = {
   users: {
-    user: Pick<User, "name" | "picture">;
+    user: Pick<User, "id" | "name" | "picture">;
   }[];
 };
 
@@ -25,9 +25,9 @@ export default function AvatarList({ users }: AvatarListPropType) {
           +{overflow}
         </div>
       )}
-      {visible.map((e, index) => (
+      {visible.map((e) => (
         <div
-          key={e.user.name ?? index}
+          key={e.user.id}
           className="relative flex justify-center items-center size-5 rounded-full text-[8px] font-bold ring-2 ring-[var(--lp-card)] shrink-0"
           style={{ background: "var(--lp-accent)", color: "white" }}
         >

--- a/components/DocThumbnail.tsx
+++ b/components/DocThumbnail.tsx
@@ -1,3 +1,10 @@
+import { PREVIEW_NODE_LIMIT } from "@/lib/documents/preview";
+
+// The preview is drawn at full size and then shrunk, which is what keeps text
+// proportioned like a page instead of like small text.
+const PREVIEW_SCALE = 0.4;
+const PREVIEW_INSET = 20;
+
 type TipTapNode = {
   type: string;
   attrs?: Record<string, unknown>;
@@ -10,6 +17,56 @@ function extractText(nodes: TipTapNode[] = []): string {
   return nodes
     .map(n => (n.text ?? "") + extractText(n.content))
     .join("");
+}
+
+// Images are inline nodes, so they arrive nested inside a paragraph rather than
+// as blocks of their own. Pulling them out is what puts them in the preview at
+// all — walking only the top level finds text and nothing else.
+function collectImages(nodes: TipTapNode[] = []): TipTapNode[] {
+  return nodes.flatMap(n =>
+    n.type === "image" ? [n] : collectImages(n.content),
+  );
+}
+
+// Tall enough that a portrait image cannot fill the whole preview on its own,
+// loose enough that it is not what decides an image's size.
+const IMAGE_MAX_HEIGHT = 420;
+
+function ThumbnailImage({ node }: { node: TipTapNode }) {
+  const src = node.attrs?.src as string | undefined;
+  if (!src) return null;
+
+  // An editor lays an image out at its own width, capped to the column, so the
+  // preview does the same.
+  //
+  // Without a recorded width the browser is left to size the image itself,
+  // which is right for exactly the case that lacks one: an image predating
+  // inline thumbnails still points at the original, so its natural size is the
+  // size the document gives it. A recorded width is only needed once `src` is a
+  // 128px stand-in that would otherwise render as a stamp.
+  const width = node.attrs?.width as number | undefined;
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt=""
+      // Inlined thumbnails cost no request, but an image from before they
+      // existed still does, and only the cards someone scrolled to should pay.
+      loading="lazy"
+      decoding="async"
+      style={{
+        ...(width ? { width: `min(${width}px, 100%)` } : { maxWidth: "100%" }),
+        height: "auto",
+        maxHeight: IMAGE_MAX_HEIGHT,
+        objectFit: "contain",
+        objectPosition: "left top",
+        borderRadius: 4,
+        marginBottom: 8,
+        display: "block",
+      }}
+    />
+  );
 }
 
 function ThumbnailNode({ node }: { node: TipTapNode }) {
@@ -34,22 +91,32 @@ function ThumbnailNode({ node }: { node: TipTapNode }) {
       );
     }
 
-    case "paragraph":
-      return text ? (
-        <div
-          style={{
-            fontSize: 13,
-            color: "var(--lp-ink)",
-            opacity: 0.8,
-            marginBottom: 6,
-            lineHeight: 1.5,
-          }}
-        >
-          {text}
-        </div>
-      ) : (
-        <div style={{ height: 10, marginBottom: 6 }} />
+    case "paragraph": {
+      const images = collectImages(node.content);
+      if (!text && images.length === 0)
+        return <div style={{ height: 10, marginBottom: 6 }} />;
+
+      return (
+        <>
+          {text && (
+            <div
+              style={{
+                fontSize: 13,
+                color: "var(--lp-ink)",
+                opacity: 0.8,
+                marginBottom: 6,
+                lineHeight: 1.5,
+              }}
+            >
+              {text}
+            </div>
+          )}
+          {images.map((image, i) => (
+            <ThumbnailImage key={i} node={image} />
+          ))}
+        </>
       );
+    }
 
     case "bulletList":
     case "orderedList":
@@ -83,25 +150,8 @@ function ThumbnailNode({ node }: { node: TipTapNode }) {
         </div>
       );
 
-    case "image": {
-      const src = node.attrs?.src as string | undefined;
-      if (!src) return null;
-      return (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={src}
-          alt=""
-          style={{
-            maxWidth: "100%",
-            maxHeight: 90,
-            objectFit: "cover",
-            borderRadius: 4,
-            marginBottom: 8,
-            display: "block",
-          }}
-        />
-      );
-    }
+    case "image":
+      return <ThumbnailImage node={node} />;
 
     // Only the top-left corner survives at this scale, so the preview shows
     // enough rows and columns to read as a table and stops there.
@@ -195,7 +245,7 @@ export default function DocThumbnail({
   try {
     if (data) {
       const parsed = JSON.parse(data) as { content?: TipTapNode[] };
-      nodes = (parsed.content ?? []).slice(0, 10);
+      nodes = (parsed.content ?? []).slice(0, PREVIEW_NODE_LIMIT);
     }
   } catch {
     // malformed JSON — fall through to empty state
@@ -228,9 +278,12 @@ export default function DocThumbnail({
       {/* Scaled document preview */}
       <div
         style={{
-          width: "340%",
-          padding: "0 20px",
-          transform: "scale(0.4)",
+          // Rendered at full size and shrunk, so the width has to be the exact
+          // inverse of the scale. Anything wider hangs off the right edge and
+          // is clipped, which is what left the padding looking lopsided.
+          width: `${100 / PREVIEW_SCALE}%`,
+          padding: `0 ${PREVIEW_INSET}px`,
+          transform: `scale(${PREVIEW_SCALE})`,
           transformOrigin: "top left",
           pointerEvents: "none",
           userSelect: "none",

--- a/lib/documents/preview.ts
+++ b/lib/documents/preview.ts
@@ -1,0 +1,70 @@
+// The dashboard draws a scaled preview of each document, which needs the top of
+// the document and nothing else. Storing that separately is what keeps a list of
+// documents from carrying their full bodies: a long document costs the same as a
+// short one to list.
+
+// A card shows roughly twenty blocks before its overflow clips the rest, so
+// this is the visible area with room to spare rather than a guess.
+export const PREVIEW_NODE_LIMIT = 25;
+
+// A single node can be arbitrarily large on its own — one long table is enough —
+// so the node count alone is not a bound. Nodes are dropped from the end until
+// the preview is small, since the thumbnail cuts off long before this anyway.
+//
+// The allowance is generous because inlined thumbnails live here: text alone
+// runs about 3KB, and each image adds up to 8KB more. Even a preview at this
+// ceiling is a fraction of the documents it stands in for.
+const PREVIEW_MAX_BYTES = 40 * 1024;
+
+type PreviewNode = {
+  type: string;
+  attrs?: Record<string, unknown>;
+  content?: PreviewNode[];
+};
+
+const serialize = (nodes: PreviewNode[]) =>
+  JSON.stringify({ type: "doc", content: nodes });
+
+/**
+ * Replaces every image with the tiny copy carried on the node itself.
+ *
+ * The point of inlining is that the picture arrives in the same payload as the
+ * text around it and paints in the same frame — a `src` pointing anywhere, however
+ * small the file, is a second request and always lands later. `thumbData` is
+ * dropped afterwards, since the preview is only ever read to draw that one box.
+ */
+const useThumbnails = (node: PreviewNode): PreviewNode => {
+  const { thumbData, ...attrs } = node.attrs ?? {};
+
+  return {
+    ...node,
+    ...(node.attrs
+      ? { attrs: typeof thumbData === "string" ? { ...attrs, src: thumbData } : attrs }
+      : {}),
+    ...(node.content ? { content: node.content.map(useThumbnails) } : {}),
+  };
+};
+
+/**
+ * The stored preview for a document body, or null when there is nothing to show.
+ *
+ * Kept beside every write of `data` rather than derived on read: a preview that
+ * lags a save shows a slightly old thumbnail, which is a far better failure than
+ * reading every document in full to render a grid of them.
+ */
+export const previewOf = (data: string | null | undefined) => {
+  if (!data) return null;
+
+  let nodes: PreviewNode[];
+  try {
+    nodes = (JSON.parse(data) as { content?: PreviewNode[] }).content ?? [];
+  } catch {
+    return null;
+  }
+
+  nodes = nodes.slice(0, PREVIEW_NODE_LIMIT).map(useThumbnails);
+  while (nodes.length > 1 && serialize(nodes).length > PREVIEW_MAX_BYTES)
+    nodes = nodes.slice(0, -1);
+
+  return serialize(nodes);
+};

--- a/lib/guestServices.ts
+++ b/lib/guestServices.ts
@@ -46,7 +46,10 @@ export const createGuestDocument = (initialData?: string) => {
     linkAccess: "NONE",
     // Importing from Google Docs needs a session, so a guest document is
     // always one someone started here.
-    source: "BLANK"
+    source: "BLANK",
+    // Only stored documents need a preview, to keep a list of them off the
+    // wire. A guest's documents are already on this machine.
+    preview: null
   }
 
   const allDocuments: Document[] = JSON.parse(localStorage.getItem('documents') || '[]');
@@ -62,13 +65,15 @@ export const getAllGuestDocuments = () => {
   const data = documents.map((doc) => {
     return {
       id: doc.id,
-      data: doc.data,
-      thumbnail: doc.thumbnail,
+      // Reading the whole body costs nothing here — it never leaves the
+      // machine — so the thumbnail draws straight from it.
+      preview: doc.data,
       name: doc.name,
       updatedAt: doc.updatedAt,
       createdBy: { id: user.id, name: user.name, picture: user.picture },
       users: [{
         user: {
+          id: user.id,
           name: user.name,
           picture: user.picture
         }

--- a/lib/hooks/useDocs.ts
+++ b/lib/hooks/useDocs.ts
@@ -1,21 +1,10 @@
 "use client";
 
 import useSWR, { mutate } from "swr";
-import type { DocumentSource } from "@prisma/client";
 
 import { GetAllDocs } from "@/app/document/actions";
 import { getAllGuestDocuments } from "@/lib/guestServices";
-
-type Doc = {
-  id: string;
-  name: string;
-  data: string | null;
-  updatedAt: Date;
-  // Absent on guest documents, which are only ever created locally.
-  source?: DocumentSource;
-  createdBy: { id: string; name: string; picture: string | null };
-  users: { user: { name: string; picture: string | null } }[];
-};
+import type { DocSummary as Doc } from "@/lib/types/document";
 
 const docsKey = (userId?: string) =>
   userId ? ["docs", userId] : ["docs", "guest"];

--- a/lib/images/signedRead.ts
+++ b/lib/images/signedRead.ts
@@ -1,0 +1,76 @@
+import {
+  issueSignedToken,
+  presignUrl,
+  type IssuedSignedToken,
+} from "@vercel/blob";
+
+// Minting a delegation token is a round trip to Vercel's control API and costs
+// around 250ms; signing a URL from one is local HMAC and costs about 1ms. Doing
+// the first per image meant a dashboard paid it once per thumbnail, so the
+// token is minted once and reused until it is close to lapsing.
+const TOKEN_TTL_MS = 30 * 60 * 1000;
+const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+// Long enough for a slow page to finish loading its images, short enough that a
+// copied URL is worthless by the time it is pasted anywhere. The margin above
+// guarantees the token always has at least this much life left, so a URL is
+// never cut short by the token behind it.
+const LINK_TTL_MS = 5 * 60 * 1000;
+
+type CachedToken = { token: IssuedSignedToken; validUntil: number };
+
+let cached: CachedToken | null = null;
+let inFlight: Promise<CachedToken> | null = null;
+
+// Scoped to the whole store rather than to one path, which is what makes it
+// reusable. It never leaves the server: callers only ever receive a URL for a
+// single path, and only after the caller has been authorised for it.
+const mintToken = async (): Promise<CachedToken> => {
+  const validUntil = Date.now() + TOKEN_TTL_MS;
+
+  const token = await issueSignedToken({
+    // Explicit for the same reason as the upload route: left out, the SDK
+    // prefers VERCEL_OIDC_TOKEN whenever BLOB_STORE_ID is set, which fails
+    // anywhere OIDC is not enabled.
+    token: process.env.BLOB_READ_WRITE_TOKEN,
+    pathname: "*",
+    operations: ["get"],
+    validUntil,
+  });
+
+  return { token, validUntil };
+};
+
+const delegationToken = async () => {
+  if (cached && cached.validUntil - REFRESH_MARGIN_MS > Date.now())
+    return cached.token;
+
+  // Without this, the first paint of a dashboard full of images would fire one
+  // mint per thumbnail before any of them resolved.
+  inFlight ??= mintToken()
+    .then((minted) => {
+      cached = minted;
+      return minted;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return (await inFlight).token;
+};
+
+/** A short-lived URL the browser can fetch one private blob with. */
+export const signedImageUrl = async (pathname: string) => {
+  const token = await delegationToken();
+
+  const { presignedUrl } = await presignUrl(token, {
+    operation: "get",
+    pathname,
+    access: "private",
+    validUntil: Date.now() + LINK_TTL_MS,
+  });
+
+  return presignedUrl;
+};
+
+export const IMAGE_LINK_TTL_MS = LINK_TTL_MS;

--- a/lib/images/upload.ts
+++ b/lib/images/upload.ts
@@ -3,6 +3,24 @@ import { uploadPresigned } from "@vercel/blob/client";
 import { ALLOWED_CONTENT_TYPES, MAX_UPLOAD_BYTES } from "./constants";
 import { blobPathname, imageSrc } from "./paths";
 
+/**
+ * What an image node ends up carrying.
+ *
+ * `thumbData` is a tiny copy of the same picture, encoded into the node itself.
+ * A dashboard draws images about 36px tall, and fetching a file for that meant
+ * the picture always arrived a beat after the text around it. Inlined, it is
+ * part of the same payload and paints in the same frame.
+ */
+export type UploadedImage = {
+  src: string;
+  thumbData: string | null;
+  // The image's own size. An editor lays an image out at its natural width,
+  // capped to the column, so a preview has to know that width to keep the
+  // picture the same size relative to the text around it.
+  width: number | null;
+  height: number | null;
+};
+
 export const isSupportedImage = (file: File) =>
   ALLOWED_CONTENT_TYPES.includes(file.type);
 
@@ -12,6 +30,14 @@ export const isSupportedImage = (file: File) =>
 const GUEST_MAX_EDGE = 1280;
 const GUEST_MAX_BYTES = 1024 * 1024;
 
+// A thumbnail renders about 36px tall, so 128px still has headroom for a
+// high-density screen while staying small enough to inline.
+const THUMBNAIL_MAX_EDGE = 128;
+const THUMBNAIL_QUALITY = 0.5;
+
+// Anything larger is not worth carrying inside every copy of the document.
+const THUMBNAIL_MAX_BYTES = 8 * 1024;
+
 const readBitmap = async (file: File) => {
   try {
     return await createImageBitmap(file);
@@ -20,12 +46,15 @@ const readBitmap = async (file: File) => {
   }
 };
 
-const toDataUrl = async (file: File) => {
+// A canvas keeps only the first frame of a GIF, so animation is lost either
+// way; PNG is kept for its transparency and everything else becomes JPEG.
+const outputTypeFor = (file: File) =>
+  file.type === "image/png" ? "image/png" : "image/jpeg";
+
+const drawScaled = async (file: File, maxEdge: number) => {
   const bitmap = await readBitmap(file);
-  const scale = Math.min(
-    1,
-    GUEST_MAX_EDGE / Math.max(bitmap.width, bitmap.height),
-  );
+  const natural = { width: bitmap.width, height: bitmap.height };
+  const scale = Math.min(1, maxEdge / Math.max(bitmap.width, bitmap.height));
 
   const canvas = document.createElement("canvas");
   canvas.width = Math.round(bitmap.width * scale);
@@ -37,23 +66,54 @@ const toDataUrl = async (file: File) => {
   context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
   bitmap.close();
 
-  // A canvas keeps only the first frame of a GIF, so animation is lost either
-  // way; PNG is kept for its transparency and everything else becomes JPEG.
-  const dataUrl = canvas.toDataURL(
-    file.type === "image/png" ? "image/png" : "image/jpeg",
-    0.8,
-  );
+  return { canvas, natural };
+};
+
+const toDataUrl = async (file: File) => {
+  const { canvas } = await drawScaled(file, GUEST_MAX_EDGE);
+  const dataUrl = canvas.toDataURL(outputTypeFor(file), 0.8);
 
   if (dataUrl.length > GUEST_MAX_BYTES)
     throw new Error("Sign in to add images this large");
 
-  return dataUrl;
+  // A guest's image is re-encoded rather than stored as it arrived, so the
+  // canvas dimensions are the ones the document will lay out.
+  return { dataUrl, width: canvas.width, height: canvas.height };
 };
 
 /**
- * Resolves to the `src` an image node should carry.
+ * The inline thumbnail, or null when one cannot be made small enough.
  *
- * Signed-in uploads go to Blob storage and come back as a URL. Guests have no
+ * WebP is asked for first because it is the only one of the three that is both
+ * small and keeps transparency — a logo on a page would otherwise need PNG,
+ * which at this quality is several times the size. A browser that cannot encode
+ * it returns PNG instead of failing, so the result is checked rather than
+ * assumed, and JPEG is the fallback.
+ */
+const toInlineThumbnail = async (file: File) => {
+  try {
+    const { canvas, natural } = await drawScaled(file, THUMBNAIL_MAX_EDGE);
+
+    const webp = canvas.toDataURL("image/webp", THUMBNAIL_QUALITY);
+    const dataUrl = webp.startsWith("data:image/webp")
+      ? webp
+      : canvas.toDataURL("image/jpeg", THUMBNAIL_QUALITY);
+
+    return {
+      ...natural,
+      thumbData: dataUrl.length > THUMBNAIL_MAX_BYTES ? null : dataUrl,
+    };
+  } catch {
+    // A missing thumbnail costs a slower dashboard, nothing more, so it must
+    // never be the reason an image fails to go into a document.
+    return null;
+  }
+};
+
+/**
+ * Puts an image where a document can point at it.
+ *
+ * Signed-in uploads go to Blob storage and come back as URLs. Guests have no
  * session to mint an upload token with, so their images are inlined into the
  * document itself — which is also where guest documents already live.
  */
@@ -61,11 +121,14 @@ export const resolveImageSrc = async (
   file: File,
   docId: string,
   isSignedIn: boolean,
-) => {
+): Promise<UploadedImage> => {
   if (!isSupportedImage(file))
     throw new Error("Only PNG, JPEG, GIF and WebP images are supported");
 
-  if (!isSignedIn) return toDataUrl(file);
+  if (!isSignedIn) {
+    const { dataUrl, width, height } = await toDataUrl(file);
+    return { src: dataUrl, thumbData: null, width, height };
+  }
 
   if (file.size > MAX_UPLOAD_BYTES)
     throw new Error("Images must be under 5MB");
@@ -77,11 +140,19 @@ export const resolveImageSrc = async (
   // The store is private — it refuses a public write outright — so the returned
   // storage URL is not something an <img> can load. The document points at the
   // image route instead, which serves it to readers of this document.
-  const blob = await uploadPresigned(blobPathname(docId, file.name), file, {
-    access: "private",
-    handleUploadUrl: "/api/upload",
-    clientPayload: docId,
-  });
+  const [blob, thumbnail] = await Promise.all([
+    uploadPresigned(blobPathname(docId, file.name), file, {
+      access: "private",
+      handleUploadUrl: "/api/upload",
+      clientPayload: docId,
+    }),
+    toInlineThumbnail(file),
+  ]);
 
-  return imageSrc(blob.pathname);
+  return {
+    src: imageSrc(blob.pathname),
+    thumbData: thumbnail?.thumbData ?? null,
+    width: thumbnail?.width ?? null,
+    height: thumbnail?.height ?? null,
+  };
 };

--- a/lib/types/document.ts
+++ b/lib/types/document.ts
@@ -1,0 +1,21 @@
+import type { DocumentSource } from "@prisma/client";
+
+/**
+ * A document as the dashboard needs it: enough to draw a card, no more.
+ *
+ * The same shape is produced three ways — the server component's first paint,
+ * the `GetAllDocs` action behind SWR, and localStorage for guests — so it lives
+ * here rather than being restated at each one, where the three drift apart.
+ */
+export type DocSummary = {
+  id: string;
+  name: string;
+  // The top of the document, not the document. Nothing on a dashboard needs the
+  // body, and sending it made listing cost whatever people had written.
+  preview: string | null;
+  updatedAt: Date;
+  // Absent on guest documents, which are only ever created locally.
+  source?: DocumentSource;
+  createdBy: { id: string; name: string; picture: string | null };
+  users: { user: { id: string; name: string; picture: string | null } }[];
+};

--- a/prisma/migrations/20260819140000_document_preview/migration.sql
+++ b/prisma/migrations/20260819140000_document_preview/migration.sql
@@ -1,0 +1,26 @@
+ALTER TABLE "Document" ADD COLUMN "preview" TEXT;
+
+-- Existing rows are backfilled here rather than left to be filled in on the
+-- next save, which for a document nobody edits again would be never — and a
+-- missing preview means a blank thumbnail.
+--
+-- `pg_input_is_valid` guards the cast: `data` is always written by
+-- JSON.stringify, but one unparseable row would otherwise fail the migration
+-- for every document.
+UPDATE "Document"
+SET "preview" = jsonb_build_object(
+  'type', 'doc',
+  'content', COALESCE(
+    (
+      SELECT jsonb_agg(node)
+      FROM (
+        SELECT node
+        FROM jsonb_array_elements(("data"::jsonb) -> 'content') AS node
+        LIMIT 10
+      ) trimmed
+    ),
+    '[]'::jsonb
+  )
+)::text
+WHERE NULLIF("data", '') IS NOT NULL
+  AND pg_input_is_valid("data", 'jsonb');

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,10 @@ model Document {
   linkAccess LinkAccess     @default(NONE)
   source     DocumentSource @default(BLANK)
 
+  // The top of `data`, kept so listing documents never has to read their
+  // bodies. Written beside every write of `data`; see lib/documents/preview.ts.
+  preview String?
+
   // Hash of `data` as of the last fully successful index. A mismatch against
   // the current data means the chunks are stale — indexing failed, or the
   // document was written by a path that does not index.


### PR DESCRIPTION
Images worked after #72 but were slow to appear, and chasing that turned up something bigger: the dashboard was fetching every document in full to draw a thumbnail of its first page.

## Listing stopped carrying document bodies

`GetAllDocs` and the server component both selected `data`, so opening the dashboard shipped every document's entire text — twice, once in the RSC payload and again when SWR refetched. 59 documents came to 195KB, and it grew with whatever people wrote.

`Document.preview` now holds the top of the document — the first 25 top-level nodes, capped by size — written beside every write of `data`, and backfilled in the migration so documents nobody edits again are not left blank. On a realistic document that is 37198 bytes of body against a 1206 byte preview.

Twenty-five is where it stops being useful rather than a round number: a card is about 216px tall and renders its contents at 0.4 scale, so roughly twenty blocks fit before the overflow clips the rest. Fifty would have cost 353KB across the same 59 documents — worse than the full bodies it replaced.

Two things had to move first:

- **Duplicating is a server action now.** It read `data` from the listing and posted it back, so the browser held every document's body on the chance someone pressed duplicate. It also created the copy and renamed it in two round trips, which briefly left it called "Untitled Document".
- **Autosave stopped reading the whole row.** `UpdateDocData` ran `findFirst` with no `select` purely to check the document existed, pulling the full body out of Postgres on every debounced keystroke.

## Thumbnails paint in one frame

An image node stores a 128px WebP of itself as a data URI, encoded in the browser at upload from the bitmap already decoded for the size check. The preview swaps each `src` for it, so a dashboard now makes **no image requests at all** — no `/api/image` hop, no access check, no redirect. The picture arrives in the same JSON as the text.

WebP because it is the only one of the three that is both small and keeps transparency; a browser that cannot encode it returns PNG instead of failing, so the result is checked and JPEG is the fallback. Over 8KB it is dropped rather than carried.

Uploads also record the image's natural width and height. Those are real attributes, so the editor's `<img>` reserves the right space before loading, and the preview can draw the picture at the size the document gives it. Without them a 128px stand-in would render as a stamp.

## Thumbnails render what documents contain

- **Images were invisible.** They are inline nodes, so they sit inside a paragraph and never reached the `image` case, which only ever saw top-level blocks.
- **Images were the wrong size.** A hard `maxHeight: 90` squashed every picture into a strip regardless of shape. Now it is `min(width, 100%)` with `height: auto` — the rule the editor already uses — and `maxHeight` is only a backstop against a tall portrait filling the card. An image with no recorded width is left to size itself, which is correct for exactly the case that lacks one: it still points at the original.
- **Padding was lopsided.** The scaled inner element was `340%` wide at `0.4` scale, so it rendered at 136% of the container and 36% hung off the right. Width is now derived from the scale.

## Serving got cheaper

`issueSignedToken` is a round trip to Vercel's control API and measured 250–330ms; signing a URL from an existing token is local HMAC at 1–4ms. It was being paid per image. One store-wide token is now minted per instance and reused until it nears expiry, with an in-flight guard so a first paint cannot fire one mint per thumbnail. The redirect is cacheable for four minutes, held under the five-minute life of the URL it points at.

## Avatars

`AvatarList` keyed children by `user.name`, which collides when two collaborators share a display name — as two accounts on this database do. Keyed by id, and `id` is selected for it.

Worth a separate look: that collision means two distinct `User` rows carry the same name. `UserOnDocument` is keyed `[userId, documentId]`, so it cannot be one person twice.

## Notes

`20260819140000_document_preview` adds the column and backfills it, with `pg_input_is_valid` guarding the cast so one unparseable row cannot fail the migration.

Images uploaded before this have no inline copy and no recorded dimensions. They fall back to their original URL at natural size — correct, just not free. Re-uploading fixes both.

Imported images get no inline copy either: `rehostImages` runs server-side with no canvas, and Blob's `optimizeImage` requires OIDC and bills per transformation.

`tsc --noEmit` and `next lint` clean. `previewOf` was verified by running it: node cap, byte cap, the thumbnail swap, images nested in table cells, and null on empty, malformed and missing input.
